### PR TITLE
Add support for the `ray_tracing_pipeline_trace_rays_indirect` device feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.26"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e53b0a3d5760cd2ba9b787ae0c6440ad18ee294ff71b05e3381c900a7d16cfd"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -14,33 +14,33 @@ dependencies = [
 
 [[package]]
 name = "ab_glyph_rasterizer"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -48,23 +48,21 @@ dependencies = [
 
 [[package]]
 name = "android-activity"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6978589202a00cd7e118380c448a08b6ed394c3a8df3a430d0898e3a42d046"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
 dependencies = [
  "android-properties",
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "cc",
- "cesu8",
  "jni",
- "jni-sys",
  "libc",
  "log",
  "ndk",
  "ndk-context",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -75,15 +73,15 @@ checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -120,9 +118,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "autogen"
@@ -143,17 +141,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-link",
 ]
 
 [[package]]
@@ -179,11 +177,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -192,7 +190,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -207,24 +205,24 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.7.0"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -233,58 +231,53 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "calloop"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
+checksum = "b99da2f8558ca23c71f4fd15dc57c906239752dd27ff3c00a1d56b685b7cbfec"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "log",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "calloop-wayland-source"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0ea9b9476c7fad82841a8dbb380e2eae480c21910feba80725b46931ed8f02"
+checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop",
- "rustix",
+ "rustix 0.38.44",
  "wayland-backend",
  "wayland-client",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -349,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
@@ -379,39 +372,39 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cursor-icon"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
 name = "debug"
@@ -438,10 +431,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
-name = "dlib"
-version = "0.5.2"
+name = "dispatch2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
  "libloading",
 ]
@@ -454,9 +457,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
+checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
 name = "dynamic-buffers"
@@ -477,34 +480,40 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "fdeflate"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.30"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -518,9 +527,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -550,20 +559,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
-name = "gethostname"
-version = "0.4.3"
+name = "futures-core"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "libc",
- "windows-targets 0.48.5",
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -571,10 +604,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.29.0"
+name = "getrandom"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gl-interop"
@@ -600,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "glam"
-version = "0.29.0"
+version = "0.29.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28091a37a5d09b555cb6628fd954da299b536433834f5b8e59eba78e0cbbf8a"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
 
 [[package]]
 name = "glium"
@@ -623,22 +679,22 @@ dependencies = [
 
 [[package]]
 name = "glutin"
-version = "0.32.2"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03642b8b0cce622392deb0ee3e88511f75df2daac806102597905c3ea1974848"
+checksum = "12124de845cacfebedff80e877bb37b5b75c34c5a4c89e47e1cdd67fb6041325"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "cfg_aliases",
  "cgl",
- "core-foundation",
- "dispatch",
+ "dispatch2",
  "glutin_egl_sys",
  "glutin_glx_sys",
  "glutin_wgl_sys",
  "libloading",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "raw-window-handle",
  "wayland-sys",
@@ -689,20 +745,21 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -712,9 +769,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "image"
@@ -748,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -788,47 +845,86 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-macros",
+ "jni-sys 0.4.1",
  "log",
- "thiserror",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
-version = "0.1.31"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -840,64 +936,70 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
-version = "0.8.3"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.5",
+ "windows-link",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.0.2"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "libc",
- "redox_syscall 0.4.1",
+ "plain",
+ "redox_syscall 0.9.0",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
-version = "0.9.4"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -928,11 +1030,11 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
  "simd-adler32",
 ]
 
@@ -982,13 +1084,13 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.5.0",
- "jni-sys",
+ "bitflags 2.13.0",
+ "jni-sys 0.3.1",
  "log",
  "ndk-sys",
  "num_enum",
  "raw-window-handle",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1003,7 +1105,7 @@ version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.1",
 ]
 
 [[package]]
@@ -1018,18 +1120,19 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02339744ee7253741199f897151b38e72257d13802d4ee837285cc2990a90845"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1054,19 +1157,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
  "libc",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-data",
  "objc2-core-image",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -1075,11 +1199,11 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1089,8 +1213,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1099,10 +1223,21 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1112,9 +1247,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
- "objc2-metal",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -1124,16 +1259,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -1141,11 +1276,22 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1155,9 +1301,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
  "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1166,10 +1312,21 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -1178,11 +1335,24 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
- "objc2",
- "objc2-foundation",
- "objc2-metal",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -1191,8 +1361,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1201,16 +1371,16 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-image",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -1223,8 +1393,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
  "block2",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -1233,18 +1403,18 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
- "objc2",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1270,33 +1440,34 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "orbclient"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
 dependencies = [
+ "libc",
  "libredox",
 ]
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.21.0"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b41438d2fc63c46c74a2203bf5ccd82c41ba04347b2fcf5754f230b167067d5"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
  "ttf-parser",
 ]
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1304,37 +1475,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.18",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-link",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1343,9 +1514,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pipeline-caching"
@@ -1357,15 +1528,21 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
-version = "0.17.13"
+version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
@@ -1376,30 +1553,32 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.7.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
- "tracing",
- "windows-sys 0.52.0",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1407,18 +1586,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1443,21 +1622,33 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.31.0"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1486,7 +1677,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1497,13 +1688,14 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "raw-window-metal"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2000e45d7daa9b6d946e88dfa1d7ae330424a81918a6545741821c989eb80a9"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
 dependencies = [
- "objc2",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -1540,11 +1732,20 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5102a6aaa05aa011a238e178e6bca86d2cb56fc9f586d37cb80f5bca6e07759"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1554,7 +1755,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64",
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "serde",
  "serde_derive",
 ]
@@ -1579,28 +1780,50 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
-name = "rustix"
-version = "0.38.34"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags 2.5.0",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.52.0",
+ "semver",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustix"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "same-file"
@@ -1625,9 +1848,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sctk-adwaita"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7555fcb4f753d095d734fdefebb0ad8c98478a21db500492d87c55913d3b0086"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
 dependencies = [
  "ab_glyph",
  "log",
@@ -1645,19 +1868,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.203"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1666,13 +1905,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1703,10 +1944,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
+name = "shlex"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple-particles"
@@ -1719,12 +1982,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "slabbin"
@@ -1734,25 +1994,25 @@ checksum = "9db491c0d4152a069911a0fbdaca959691bf0b9d7110d98a7ed1c8e59b79ab30"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smithay-client-toolkit"
-version = "0.18.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
+checksum = "3457dea1f0eb631b4034d61d4d8c32074caa6cd1ab2d59f2327bd8461e2c0016"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
  "libc",
  "log",
  "memmap2",
- "rustix",
- "thiserror",
+ "rustix 0.38.44",
+ "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
  "wayland-csd-frame",
@@ -1788,9 +2048,9 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1828,18 +2088,38 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1848,12 +2128,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -1883,26 +2162,39 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -1910,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 
 [[package]]
 name = "triangle"
@@ -1945,27 +2237,27 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.21.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "virtual-buffer"
@@ -1974,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b434093a2de01d3b27e6246b0ececca4cc2a77f046bef06a9dc1216e3d892a91"
 dependencies = [
  "libc",
- "windows-targets 0.52.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2066,52 +2358,47 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.92"
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
+ "wit-bindgen",
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.92"
+name = "wasm-bindgen"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
- "bumpalo",
- "log",
+ "cfg-if",
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
+ "rustversion",
+ "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2119,32 +2406,35 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.3"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d50fa61ce90d76474c87f5fc002828d81b32677340112b4ef08079a9d459a40"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -2152,12 +2442,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.2"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
 dependencies = [
- "bitflags 2.5.0",
- "rustix",
+ "bitflags 2.13.0",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -2168,29 +2458,29 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "cursor-icon",
  "wayland-backend",
 ]
 
 [[package]]
 name = "wayland-cursor"
-version = "0.31.1"
+version = "0.31.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71ce5fa868dd13d11a0d04c5e2e65726d0897be8de247c0c5a65886e283231ba"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "wayland-client",
  "xcursor",
 ]
 
 [[package]]
 name = "wayland-protocols"
-version = "0.31.2"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2198,11 +2488,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-plasma"
-version = "0.2.0"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2211,11 +2501,11 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols-wlr"
-version = "0.2.0"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -2224,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.1"
+version = "0.31.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b3a62929287001986fb58c789dce9b67604a397c15c611ad9f747300b6c283"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -2235,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.1"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0c8eaff5216d07f226cb7a549159267f3467b289d9a2e52fd3ef5aae2b7af"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
@@ -2247,9 +2537,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2267,21 +2557,18 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.45.0"
+name = "windows-link"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -2289,197 +2576,101 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.30.3"
+version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f45a7b7e2de6af35448d7718dab6d95acec466eb3bb7a56f4d31d1af754004"
+checksum = "a6755fa58a9f8350bd1e472d4c3fcc25f824ec358933bba33306d0b63df5978d"
 dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "block2",
  "bytemuck",
  "calloop",
@@ -2493,16 +2684,16 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix",
+ "rustix 0.38.44",
  "sctk-adwaita",
  "smithay-client-toolkit",
  "smol_str",
@@ -2524,12 +2715,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "x11-dl"
@@ -2544,30 +2741,30 @@ dependencies = [
 
 [[package]]
 name = "x11rb"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
  "libloading",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xcursor"
-version = "0.3.5"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0ccd7b4a5345edfcd0c3535718a4e9ff7798ffc536bb5b5a0e26ff84732911"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
 name = "xkbcommon-dl"
@@ -2575,7 +2772,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.13.0",
  "dlib",
  "log",
  "once_cell",
@@ -2584,32 +2781,38 @@ dependencies = [
 
 [[package]]
 name = "xkeysym"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054a8e68b76250b253f671d1268cb7f1ae089ec35e195b2efb2a4e9a836d0621"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.20"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791978798f0597cfc70478424c2b4fdc2b7a8024aaff78497ef00f24ef674193"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
@@ -1226,11 +1226,11 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Performs multiple ray tracing operations using a ray tracing pipeline, panicking on a
-    /// validation error.
+    /// Performs a single ray tracing operation using a ray tracing pipeline, reading the
+    /// ray trace query dimensions from a separate buffer.
     ///
-    /// One ray tracing operation is performed for each `TraceRaysIndirectCommand` struct that
-    /// is read from `buffer`.
+    /// A single ray tracing operation is performed for the `TraceRaysIndirectCommand` struct that
+    /// is read from `buffer` starting at `offset`.
     ///
     /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
     /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
@@ -1256,11 +1256,13 @@ impl RecordingCommandBuffer<'_> {
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         buffer: Id<Buffer>,
+        offset: DeviceSize,
     ) -> &mut Self {
-        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, buffer) }.unwrap()
+        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, buffer, offset) }
+            .unwrap()
     }
 
-    /// Performs multiple ray tracing operations using a ray tracing pipeline.
+    /// Performs multiple ray tracing operations using a ray tracing pipeline
     ///
     /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
     /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
@@ -1278,14 +1280,18 @@ impl RecordingCommandBuffer<'_> {
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         buffer: Id<Buffer>,
+        offset: DeviceSize,
     ) -> Result<&mut Self> {
-        Ok(unsafe { self.trace_rays_indirect_unchecked(shader_binding_table_addresses, buffer) })
+        Ok(unsafe {
+            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, buffer, offset)
+        })
     }
 
     pub unsafe fn trace_rays_indirect_unchecked(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         buffer: Id<Buffer>,
+        offset: DeviceSize,
     ) -> &mut Self {
         let buffer = unsafe { self.accesses.buffer_unchecked(buffer) };
 
@@ -1302,7 +1308,7 @@ impl RecordingCommandBuffer<'_> {
                 &miss,
                 &hit,
                 &callable,
-                buffer.device_address().into(),
+                buffer.device_address().get() + offset,
             )
         };
 

--- a/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
@@ -1226,11 +1226,9 @@ impl RecordingCommandBuffer<'_> {
         self
     }
 
-    /// Performs a single ray tracing operation using a ray tracing pipeline, reading the
-    /// ray trace query dimensions from a separate buffer.
-    ///
-    /// A single ray tracing operation is performed for the `TraceRaysIndirectCommand` struct that
-    /// is read from `buffer` starting at `offset`.
+    /// Performs a single ray tracing operation using a ray tracing pipeline, panicking on a  
+    /// validation error. One ray tracing operation is performed for the  
+    /// [`TraceRaysIndirectCommand`] struct that is read from `indirect_device_address`.
     ///
     /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
     /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
@@ -1263,7 +1261,9 @@ impl RecordingCommandBuffer<'_> {
         .unwrap()
     }
 
-    /// Performs multiple ray tracing operations using a ray tracing pipeline
+    /// Performs a single ray tracing operation using a ray tracing pipeline. One ray tracing  
+    /// operation is performed for the [`TraceRaysIndirectCommand`] struct that is read from  
+    /// `indirect_device_address`.
     ///
     /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
     /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set

--- a/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
@@ -8,8 +8,7 @@ use vulkano::command_buffer::{
     DrawMeshTasksIndirectCommand,
 };
 use vulkano::{
-    buffer::Buffer, device::DeviceOwned, pipeline::ray_tracing::ShaderBindingTableAddresses,
-    DeviceSize, Version, VulkanObject,
+    DeviceAddress, DeviceSize, Version, VulkanObject, buffer::Buffer, device::DeviceOwned, pipeline::ray_tracing::ShaderBindingTableAddresses,
 };
 
 /// # Commands to execute a bound pipeline
@@ -1255,10 +1254,9 @@ impl RecordingCommandBuffer<'_> {
     pub unsafe fn trace_rays_indirect(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
-        buffer: Id<Buffer>,
-        offset: DeviceSize,
+        indirect_device_address: DeviceAddress,
     ) -> &mut Self {
-        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, buffer, offset) }
+        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, indirect_device_address) }
             .unwrap()
     }
 
@@ -1279,22 +1277,18 @@ impl RecordingCommandBuffer<'_> {
     pub unsafe fn try_trace_rays_indirect(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
-        buffer: Id<Buffer>,
-        offset: DeviceSize,
+        indirect_device_address: DeviceAddress,
     ) -> Result<&mut Self> {
         Ok(unsafe {
-            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, buffer, offset)
+            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_device_address)
         })
     }
 
     pub unsafe fn trace_rays_indirect_unchecked(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
-        buffer: Id<Buffer>,
-        offset: DeviceSize,
+        indirect_device_address: DeviceAddress,
     ) -> &mut Self {
-        let buffer = unsafe { self.accesses.buffer_unchecked(buffer) };
-
         let raygen = shader_binding_table_addresses.raygen.to_vk();
         let miss = shader_binding_table_addresses.miss.to_vk();
         let hit = shader_binding_table_addresses.hit.to_vk();
@@ -1308,7 +1302,7 @@ impl RecordingCommandBuffer<'_> {
                 &miss,
                 &hit,
                 &callable,
-                buffer.device_address().get() + offset,
+                indirect_device_address,
             )
         };
 

--- a/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
@@ -8,7 +8,8 @@ use vulkano::command_buffer::{
     DrawMeshTasksIndirectCommand,
 };
 use vulkano::{
-    DeviceAddress, DeviceSize, Version, VulkanObject, buffer::Buffer, device::DeviceOwned, pipeline::ray_tracing::ShaderBindingTableAddresses,
+    buffer::Buffer, device::DeviceOwned, pipeline::ray_tracing::ShaderBindingTableAddresses,
+    DeviceAddress, DeviceSize, Version, VulkanObject,
 };
 
 /// # Commands to execute a bound pipeline
@@ -1256,8 +1257,10 @@ impl RecordingCommandBuffer<'_> {
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         indirect_device_address: DeviceAddress,
     ) -> &mut Self {
-        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, indirect_device_address) }
-            .unwrap()
+        unsafe {
+            self.try_trace_rays_indirect(shader_binding_table_addresses, indirect_device_address)
+        }
+        .unwrap()
     }
 
     /// Performs multiple ray tracing operations using a ray tracing pipeline
@@ -1280,7 +1283,10 @@ impl RecordingCommandBuffer<'_> {
         indirect_device_address: DeviceAddress,
     ) -> Result<&mut Self> {
         Ok(unsafe {
-            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_device_address)
+            self.trace_rays_indirect_unchecked(
+                shader_binding_table_addresses,
+                indirect_device_address,
+            )
         })
     }
 

--- a/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
@@ -1228,7 +1228,7 @@ impl RecordingCommandBuffer<'_> {
 
     /// Performs multiple ray tracing operations using a ray tracing pipeline, panicking on a
     /// validation error.
-    /// 
+    ///
     /// One ray tracing operation is performed for each `TraceRaysIndirectCommand` struct that
     /// is read from `buffer`.
     ///
@@ -1300,7 +1300,7 @@ impl RecordingCommandBuffer<'_> {
                 &miss,
                 &hit,
                 &callable,
-                buffer.device_address().into()
+                buffer.device_address().into(),
             )
         };
 

--- a/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
@@ -1225,4 +1225,85 @@ impl RecordingCommandBuffer<'_> {
 
         self
     }
+
+    /// Performs multiple ray tracing operations using a ray tracing pipeline, panicking on a
+    /// validation error.
+    /// 
+    /// One ray tracing operation is performed for each `TraceRaysIndirectCommand` struct that
+    /// is read from `buffer`.
+    ///
+    /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
+    /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
+    /// beforehand.
+    ///
+    /// This is a shortcut for `try_trace_rays_indirect().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `TraceRaysIndirectCommand`] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_trace_rays_indirect`] returns a [`ValidationError`].
+    ///
+    /// [`bind_pipeline_ray_tracing`]: Self::bind_pipeline_ray_tracing
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `TraceRaysIndirectCommand`]: TraceRaysIndirectCommand#safety
+    /// [`try_trace_rays_indirect`]: Self::try_trace_rays_indirect
+    #[track_caller]
+    pub unsafe fn trace_rays_indirect(
+        &mut self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        buffer: Id<Buffer>,
+    ) -> &mut Self {
+        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, buffer) }.unwrap()
+    }
+
+    /// Performs multiple ray tracing operations using a ray tracing pipeline.
+    ///
+    /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
+    /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
+    /// beforehand.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    ///
+    /// [`bind_pipeline_ray_tracing`]: Self::bind_pipeline_ray_tracing
+    /// [shader safety requirements]: vulkano::shader#safety
+    pub unsafe fn try_trace_rays_indirect(
+        &mut self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        buffer: Id<Buffer>,
+    ) -> Result<&mut Self> {
+        Ok(unsafe { self.trace_rays_indirect_unchecked(shader_binding_table_addresses, buffer) })
+    }
+
+    pub unsafe fn trace_rays_indirect_unchecked(
+        &mut self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        buffer: Id<Buffer>,
+    ) -> &mut Self {
+        let buffer = unsafe { self.accesses.buffer_unchecked(buffer) };
+
+        let raygen = shader_binding_table_addresses.raygen.to_vk();
+        let miss = shader_binding_table_addresses.miss.to_vk();
+        let hit = shader_binding_table_addresses.hit.to_vk();
+        let callable = shader_binding_table_addresses.callable.to_vk();
+
+        let fns = self.device().fns();
+        unsafe {
+            (fns.khr_ray_tracing_pipeline.cmd_trace_rays_indirect_khr)(
+                self.handle(),
+                &raygen,
+                &miss,
+                &hit,
+                &callable,
+                buffer.device_address().into()
+            )
+        };
+
+        self
+    }
 }

--- a/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
+++ b/vulkano-taskgraph/src/command_buffer/commands/pipeline.rs
@@ -1269,9 +1269,11 @@ impl RecordingCommandBuffer<'_> {
     /// # Safety
     ///
     /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `TraceRaysIndirectCommand`] apply.
     ///
     /// [`bind_pipeline_ray_tracing`]: Self::bind_pipeline_ray_tracing
     /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `TraceRaysIndirectCommand`]: TraceRaysIndirectCommand#safety
     pub unsafe fn try_trace_rays_indirect(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -1,17 +1,35 @@
 #[cfg(doc)]
 use crate::device::{DeviceFeatures, DeviceProperties};
 use crate::{
-    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject, acceleration_structure::AccelerationStructure, buffer::{BufferUsage, Subbuffer, view::BufferView}, command_buffer::{
-        AutoCommandBufferBuilder, DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand, DrawMeshTasksIndirectCommand, ResourceInCommand, SubpassContents, TraceRaysIndirectCommand, auto::{RenderPassState, RenderPassStateType, Resource, ResourceUseRef2}, sys::RecordingCommandBuffer,
-    }, descriptor_set::{
-        DescriptorBindingResources, OwnedDescriptorBufferInfo, OwnedDescriptorImageInfo, layout::{DescriptorBindingFlags, DescriptorType},
-    }, device::DeviceOwned, format::{FormatFeatures, NumericType}, image::{ImageAspects, ImageLayout, SampleCount, sampler::Sampler, view::ImageView}, pipeline::{
-        DynamicState, GraphicsPipeline, Pipeline, PipelineLayout, graphics::{
+    acceleration_structure::AccelerationStructure,
+    buffer::{view::BufferView, BufferUsage, Subbuffer},
+    command_buffer::{
+        auto::{RenderPassState, RenderPassStateType, Resource, ResourceUseRef2},
+        sys::RecordingCommandBuffer,
+        AutoCommandBufferBuilder, DispatchIndirectCommand, DrawIndexedIndirectCommand,
+        DrawIndirectCommand, DrawMeshTasksIndirectCommand, ResourceInCommand, SubpassContents,
+        TraceRaysIndirectCommand,
+    },
+    descriptor_set::{
+        layout::{DescriptorBindingFlags, DescriptorType},
+        DescriptorBindingResources, OwnedDescriptorBufferInfo, OwnedDescriptorImageInfo,
+    },
+    device::DeviceOwned,
+    format::{FormatFeatures, NumericType},
+    image::{sampler::Sampler, view::ImageView, ImageAspects, ImageLayout, SampleCount},
+    pipeline::{
+        graphics::{
             input_assembly::PrimitiveTopology,
             subpass::PipelineSubpassType,
             vertex_input::{RequiredVertexInputsVUIDs, VertexInputRate},
-        }, ray_tracing::ShaderBindingTableAddresses,
-    }, query::QueryType, shader::{DescriptorBindingRequirements, DescriptorIdentifier, ShaderStages}, sync::{PipelineStageAccess, PipelineStageAccessFlags},
+        },
+        ray_tracing::ShaderBindingTableAddresses,
+        DynamicState, GraphicsPipeline, Pipeline, PipelineLayout,
+    },
+    query::QueryType,
+    shader::{DescriptorBindingRequirements, DescriptorIdentifier, ShaderStages},
+    sync::{PipelineStageAccess, PipelineStageAccessFlags},
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
 use std::sync::Arc;
 
@@ -1716,7 +1734,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_buffer)
         })
     }
-    
+
     fn validate_trace_rays_indirect(
         &self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -1734,7 +1734,7 @@ impl<L> AutoCommandBufferBuilder<L> {
     ) -> Result<&mut Self, Box<ValidationError>> {
         self.inner.validate_trace_rays_indirect(
             &shader_binding_table_addresses,
-            &indirect_buffer.buffer(),
+            indirect_buffer.buffer(),
         )?;
 
         Ok(unsafe {

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -1,34 +1,17 @@
 #[cfg(doc)]
 use crate::device::{DeviceFeatures, DeviceProperties};
 use crate::{
-    acceleration_structure::AccelerationStructure,
-    buffer::{view::BufferView, Subbuffer},
-    command_buffer::{
-        auto::{RenderPassState, RenderPassStateType, Resource, ResourceUseRef2},
-        sys::RecordingCommandBuffer,
-        AutoCommandBufferBuilder, DispatchIndirectCommand, DrawIndexedIndirectCommand,
-        DrawIndirectCommand, DrawMeshTasksIndirectCommand, ResourceInCommand, SubpassContents,
-    },
-    descriptor_set::{
-        layout::{DescriptorBindingFlags, DescriptorType},
-        DescriptorBindingResources, OwnedDescriptorBufferInfo, OwnedDescriptorImageInfo,
-    },
-    device::DeviceOwned,
-    format::{FormatFeatures, NumericType},
-    image::{sampler::Sampler, view::ImageView, ImageAspects, ImageLayout, SampleCount},
-    pipeline::{
-        graphics::{
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject, acceleration_structure::AccelerationStructure, buffer::{Subbuffer, view::BufferView}, command_buffer::{
+        AutoCommandBufferBuilder, DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand, DrawMeshTasksIndirectCommand, ResourceInCommand, SubpassContents, TraceRaysIndirectCommand, auto::{RenderPassState, RenderPassStateType, Resource, ResourceUseRef2}, sys::RecordingCommandBuffer
+    }, descriptor_set::{
+        DescriptorBindingResources, OwnedDescriptorBufferInfo, OwnedDescriptorImageInfo, layout::{DescriptorBindingFlags, DescriptorType}
+    }, device::DeviceOwned, format::{FormatFeatures, NumericType}, image::{ImageAspects, ImageLayout, SampleCount, sampler::Sampler, view::ImageView}, pipeline::{
+        DynamicState, GraphicsPipeline, Pipeline, PipelineLayout, graphics::{
             input_assembly::PrimitiveTopology,
             subpass::PipelineSubpassType,
             vertex_input::{RequiredVertexInputsVUIDs, VertexInputRate},
-        },
-        ray_tracing::ShaderBindingTableAddresses,
-        DynamicState, GraphicsPipeline, Pipeline, PipelineLayout,
-    },
-    query::QueryType,
-    shader::{DescriptorBindingRequirements, DescriptorIdentifier, ShaderStages},
-    sync::{PipelineStageAccess, PipelineStageAccessFlags},
-    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
+        }, ray_tracing::ShaderBindingTableAddresses
+    }, query::QueryType, shader::{DescriptorBindingRequirements, DescriptorIdentifier, ShaderStages}, sync::{PipelineStageAccess, PipelineStageAccessFlags}
 };
 use std::sync::Arc;
 
@@ -1696,6 +1679,61 @@ impl<L> AutoCommandBufferBuilder<L> {
 
         self.add_command("trace_rays", used_resources, move |out| {
             unsafe { out.trace_rays_unchecked(&shader_binding_table_addresses, dimensions) };
+        });
+
+        self
+    }
+
+    /// Performs multiple ray tracing operations using a ray tracing pipeline, panicking on a
+    /// validation error.
+    /// 
+    /// One ray tracing operation is performed for each `TraceRaysIndirectCommand` struct that
+    /// is read from `buffer`.
+    ///
+    /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
+    /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
+    /// beforehand.
+    ///
+    /// This is a shortcut for `try_trace_rays_indirect().unwrap()`.
+    ///
+    /// # Safety
+    ///
+    /// - The general [shader safety requirements] apply.
+    /// - The [safety requirements for `TraceRaysIndirectCommand`] apply.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_trace_rays_indirect`] returns a [`ValidationError`].
+    ///
+    /// [`bind_pipeline_ray_tracing`]: Self::bind_pipeline_ray_tracing
+    /// [shader safety requirements]: vulkano::shader#safety
+    /// [safety requirements for `TraceRaysIndirectCommand`]: TraceRaysIndirectCommand#safety
+    /// [`try_trace_rays_indirect`]: Self::try_trace_rays_indirect
+    pub unsafe fn trace_rays_indirect(
+        &mut self,
+        shader_binding_table_addresses: ShaderBindingTableAddresses,
+        indirect_buffer: Subbuffer<[TraceRaysIndirectCommand]>,
+    ) -> Result<&mut Self, Box<ValidationError>> {
+        self.inner
+            .validate_trace_rays_indirect(&shader_binding_table_addresses, &indirect_buffer.buffer())?;
+
+        Ok(unsafe { self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_buffer) })
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn trace_rays_indirect_unchecked(
+        &mut self,
+        shader_binding_table_addresses: ShaderBindingTableAddresses,
+        indirect_buffer: Subbuffer<[TraceRaysIndirectCommand]>,
+    ) -> &mut Self {
+        let pipeline = self.builder_state.pipeline_ray_tracing.as_deref().unwrap();
+
+        let mut used_resources = Vec::new();
+        self.add_descriptor_sets_resources(&mut used_resources, pipeline);
+        self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
+
+        self.add_command("trace_rays_indirect", used_resources, move |out| {
+            unsafe { out.trace_rays_indirect_unchecked(&shader_binding_table_addresses, indirect_buffer.buffer()) };
         });
 
         self

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -1702,11 +1702,9 @@ impl<L> AutoCommandBufferBuilder<L> {
         self
     }
 
-    /// Performs a single ray tracing operation using a ray tracing pipeline, reading the
-    /// ray trace query dimensions from a separate buffer.
-    ///
-    /// A single ray tracing operation is performed for the `TraceRaysIndirectCommand` struct that
-    /// is read from `indirect_buffer`.
+    /// Performs a single ray tracing operation using a ray tracing pipeline. One ray tracing  
+    /// operation is performed for the [`TraceRaysIndirectCommand`] struct that is read from  
+    /// `indirect_buffer`.
     ///
     /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
     /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
@@ -1751,31 +1749,9 @@ impl<L> AutoCommandBufferBuilder<L> {
 
         if !buffer.usage().intersects(BufferUsage::INDIRECT_BUFFER) {
             return Err(Box::new(ValidationError {
-                context: "buffer.usage()".into(),
+                context: "indirect_buffer.usage()".into(),
                 problem: "does not contain `BufferUsage::INDIRECT_BUFFER`".into(),
                 vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03633"],
-                ..Default::default()
-            }));
-        }
-
-        if !offset.is_multiple_of(4) {
-            return Err(Box::new(ValidationError {
-                context: "offset".into(),
-                problem: "is not a multiple of 4".into(),
-                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03634"],
-                ..Default::default()
-            }));
-        }
-
-        if offset
-            .checked_add(size_of::<TraceRaysIndirectCommand>() as DeviceSize)
-            .is_none_or(|end| end > buffer.size())
-        {
-            return Err(Box::new(ValidationError {
-                problem: "`offset + size_of::<TraceRaysIndirectCommand>()` is greater than \
-                    `buffer.size()`"
-                    .into(),
-                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03636"],
                 ..Default::default()
             }));
         }

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -1702,8 +1702,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         self
     }
 
-    /// Performs multiple ray tracing operations using a ray tracing pipeline, panicking on a
-    /// validation error.
+    /// Performs multiple ray tracing operations using a ray tracing pipeline.
     ///
     /// One ray tracing operation is performed for each `TraceRaysIndirectCommand` struct that
     /// is read from `buffer`.
@@ -1712,21 +1711,14 @@ impl<L> AutoCommandBufferBuilder<L> {
     /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
     /// beforehand.
     ///
-    /// This is a shortcut for `try_trace_rays_indirect().unwrap()`.
-    ///
     /// # Safety
     ///
     /// - The general [shader safety requirements] apply.
     /// - The [safety requirements for `TraceRaysIndirectCommand`] apply.
     ///
-    /// # Panics
-    ///
-    /// - Panics if [`try_trace_rays_indirect`] returns a [`ValidationError`].
-    ///
     /// [`bind_pipeline_ray_tracing`]: Self::bind_pipeline_ray_tracing
     /// [shader safety requirements]: vulkano::shader#safety
     /// [safety requirements for `TraceRaysIndirectCommand`]: TraceRaysIndirectCommand#safety
-    /// [`try_trace_rays_indirect`]: Self::try_trace_rays_indirect
     pub unsafe fn trace_rays_indirect(
         &mut self,
         shader_binding_table_addresses: ShaderBindingTableAddresses,

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -1702,10 +1702,11 @@ impl<L> AutoCommandBufferBuilder<L> {
         self
     }
 
-    /// Performs multiple ray tracing operations using a ray tracing pipeline.
+    /// Performs a single ray tracing operation using a ray tracing pipeline, reading the
+    /// ray trace query dimensions from a separate buffer.
     ///
-    /// One ray tracing operation is performed for each `TraceRaysIndirectCommand` struct that
-    /// is read from `buffer`.
+    /// A single ray tracing operation is performed for the `TraceRaysIndirectCommand` struct that
+    /// is read from `indirect_buffer`.
     ///
     /// A ray tracing pipeline must have been bound using [`bind_pipeline_ray_tracing`]. Any
     /// resources used by the ray tracing pipeline, such as descriptor sets, must have been set
@@ -1727,6 +1728,7 @@ impl<L> AutoCommandBufferBuilder<L> {
         self.inner.validate_trace_rays_indirect(
             &shader_binding_table_addresses,
             indirect_buffer.buffer(),
+            indirect_buffer.offset(),
         )?;
 
         Ok(unsafe {
@@ -1751,6 +1753,7 @@ impl<L> AutoCommandBufferBuilder<L> {
                 out.trace_rays_indirect_unchecked(
                     &shader_binding_table_addresses,
                     indirect_buffer.buffer(),
+                    indirect_buffer.offset(),
                 )
             };
         });

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -1,35 +1,17 @@
 #[cfg(doc)]
 use crate::device::{DeviceFeatures, DeviceProperties};
 use crate::{
-    acceleration_structure::AccelerationStructure,
-    buffer::{view::BufferView, Subbuffer},
-    command_buffer::{
-        auto::{RenderPassState, RenderPassStateType, Resource, ResourceUseRef2},
-        sys::RecordingCommandBuffer,
-        AutoCommandBufferBuilder, DispatchIndirectCommand, DrawIndexedIndirectCommand,
-        DrawIndirectCommand, DrawMeshTasksIndirectCommand, ResourceInCommand, SubpassContents,
-        TraceRaysIndirectCommand,
-    },
-    descriptor_set::{
-        layout::{DescriptorBindingFlags, DescriptorType},
-        DescriptorBindingResources, OwnedDescriptorBufferInfo, OwnedDescriptorImageInfo,
-    },
-    device::DeviceOwned,
-    format::{FormatFeatures, NumericType},
-    image::{sampler::Sampler, view::ImageView, ImageAspects, ImageLayout, SampleCount},
-    pipeline::{
-        graphics::{
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject, acceleration_structure::AccelerationStructure, buffer::{BufferUsage, Subbuffer, view::BufferView}, command_buffer::{
+        AutoCommandBufferBuilder, DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand, DrawMeshTasksIndirectCommand, ResourceInCommand, SubpassContents, TraceRaysIndirectCommand, auto::{RenderPassState, RenderPassStateType, Resource, ResourceUseRef2}, sys::RecordingCommandBuffer,
+    }, descriptor_set::{
+        DescriptorBindingResources, OwnedDescriptorBufferInfo, OwnedDescriptorImageInfo, layout::{DescriptorBindingFlags, DescriptorType},
+    }, device::DeviceOwned, format::{FormatFeatures, NumericType}, image::{ImageAspects, ImageLayout, SampleCount, sampler::Sampler, view::ImageView}, pipeline::{
+        DynamicState, GraphicsPipeline, Pipeline, PipelineLayout, graphics::{
             input_assembly::PrimitiveTopology,
             subpass::PipelineSubpassType,
             vertex_input::{RequiredVertexInputsVUIDs, VertexInputRate},
-        },
-        ray_tracing::ShaderBindingTableAddresses,
-        DynamicState, GraphicsPipeline, Pipeline, PipelineLayout,
-    },
-    query::QueryType,
-    shader::{DescriptorBindingRequirements, DescriptorIdentifier, ShaderStages},
-    sync::{PipelineStageAccess, PipelineStageAccessFlags},
-    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
+        }, ray_tracing::ShaderBindingTableAddresses,
+    }, query::QueryType, shader::{DescriptorBindingRequirements, DescriptorIdentifier, ShaderStages}, sync::{PipelineStageAccess, PipelineStageAccessFlags},
 };
 use std::sync::Arc;
 
@@ -1725,15 +1707,62 @@ impl<L> AutoCommandBufferBuilder<L> {
         shader_binding_table_addresses: ShaderBindingTableAddresses,
         indirect_buffer: Subbuffer<[TraceRaysIndirectCommand]>,
     ) -> Result<&mut Self, Box<ValidationError>> {
-        self.inner.validate_trace_rays_indirect(
+        self.validate_trace_rays_indirect(
             &shader_binding_table_addresses,
-            indirect_buffer.buffer(),
-            indirect_buffer.offset(),
+            indirect_buffer.as_bytes(),
         )?;
 
         Ok(unsafe {
             self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_buffer)
         })
+    }
+    
+    fn validate_trace_rays_indirect(
+        &self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        indirect_buffer: &Subbuffer<[u8]>,
+    ) -> Result<(), Box<ValidationError>> {
+        let buffer = indirect_buffer.buffer();
+        let offset = indirect_buffer.offset();
+        let indirect_device_address = buffer.device_address().get() + offset;
+
+        self.inner.validate_trace_rays_indirect(
+            shader_binding_table_addresses,
+            indirect_device_address,
+        )?;
+
+        if !buffer.usage().intersects(BufferUsage::INDIRECT_BUFFER) {
+            return Err(Box::new(ValidationError {
+                context: "buffer.usage()".into(),
+                problem: "does not contain `BufferUsage::INDIRECT_BUFFER`".into(),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03633"],
+                ..Default::default()
+            }));
+        }
+
+        if !offset.is_multiple_of(4) {
+            return Err(Box::new(ValidationError {
+                context: "offset".into(),
+                problem: "is not a multiple of 4".into(),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03634"],
+                ..Default::default()
+            }));
+        }
+
+        if offset
+            .checked_add(size_of::<TraceRaysIndirectCommand>() as DeviceSize)
+            .is_none_or(|end| end > buffer.size())
+        {
+            return Err(Box::new(ValidationError {
+                problem: "`offset + size_of::<TraceRaysIndirectCommand>()` is greater than \
+                    `buffer.size()`"
+                    .into(),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03636"],
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
@@ -1742,6 +1771,10 @@ impl<L> AutoCommandBufferBuilder<L> {
         shader_binding_table_addresses: ShaderBindingTableAddresses,
         indirect_buffer: Subbuffer<[TraceRaysIndirectCommand]>,
     ) -> &mut Self {
+        let buffer = indirect_buffer.buffer();
+        let offset = indirect_buffer.offset();
+        let indirect_device_address = buffer.device_address().get() + offset;
+
         let pipeline = self.builder_state.pipeline_ray_tracing.as_deref().unwrap();
 
         let mut used_resources = Vec::new();
@@ -1752,8 +1785,7 @@ impl<L> AutoCommandBufferBuilder<L> {
             unsafe {
                 out.trace_rays_indirect_unchecked(
                     &shader_binding_table_addresses,
-                    indirect_buffer.buffer(),
-                    indirect_buffer.offset(),
+                    indirect_device_address,
                 )
             };
         });

--- a/vulkano/src/command_buffer/auto/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/auto/commands/pipeline.rs
@@ -1,17 +1,35 @@
 #[cfg(doc)]
 use crate::device::{DeviceFeatures, DeviceProperties};
 use crate::{
-    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject, acceleration_structure::AccelerationStructure, buffer::{Subbuffer, view::BufferView}, command_buffer::{
-        AutoCommandBufferBuilder, DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand, DrawMeshTasksIndirectCommand, ResourceInCommand, SubpassContents, TraceRaysIndirectCommand, auto::{RenderPassState, RenderPassStateType, Resource, ResourceUseRef2}, sys::RecordingCommandBuffer
-    }, descriptor_set::{
-        DescriptorBindingResources, OwnedDescriptorBufferInfo, OwnedDescriptorImageInfo, layout::{DescriptorBindingFlags, DescriptorType}
-    }, device::DeviceOwned, format::{FormatFeatures, NumericType}, image::{ImageAspects, ImageLayout, SampleCount, sampler::Sampler, view::ImageView}, pipeline::{
-        DynamicState, GraphicsPipeline, Pipeline, PipelineLayout, graphics::{
+    acceleration_structure::AccelerationStructure,
+    buffer::{view::BufferView, Subbuffer},
+    command_buffer::{
+        auto::{RenderPassState, RenderPassStateType, Resource, ResourceUseRef2},
+        sys::RecordingCommandBuffer,
+        AutoCommandBufferBuilder, DispatchIndirectCommand, DrawIndexedIndirectCommand,
+        DrawIndirectCommand, DrawMeshTasksIndirectCommand, ResourceInCommand, SubpassContents,
+        TraceRaysIndirectCommand,
+    },
+    descriptor_set::{
+        layout::{DescriptorBindingFlags, DescriptorType},
+        DescriptorBindingResources, OwnedDescriptorBufferInfo, OwnedDescriptorImageInfo,
+    },
+    device::DeviceOwned,
+    format::{FormatFeatures, NumericType},
+    image::{sampler::Sampler, view::ImageView, ImageAspects, ImageLayout, SampleCount},
+    pipeline::{
+        graphics::{
             input_assembly::PrimitiveTopology,
             subpass::PipelineSubpassType,
             vertex_input::{RequiredVertexInputsVUIDs, VertexInputRate},
-        }, ray_tracing::ShaderBindingTableAddresses
-    }, query::QueryType, shader::{DescriptorBindingRequirements, DescriptorIdentifier, ShaderStages}, sync::{PipelineStageAccess, PipelineStageAccessFlags}
+        },
+        ray_tracing::ShaderBindingTableAddresses,
+        DynamicState, GraphicsPipeline, Pipeline, PipelineLayout,
+    },
+    query::QueryType,
+    shader::{DescriptorBindingRequirements, DescriptorIdentifier, ShaderStages},
+    sync::{PipelineStageAccess, PipelineStageAccessFlags},
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, VulkanObject,
 };
 use std::sync::Arc;
 
@@ -1686,7 +1704,7 @@ impl<L> AutoCommandBufferBuilder<L> {
 
     /// Performs multiple ray tracing operations using a ray tracing pipeline, panicking on a
     /// validation error.
-    /// 
+    ///
     /// One ray tracing operation is performed for each `TraceRaysIndirectCommand` struct that
     /// is read from `buffer`.
     ///
@@ -1714,10 +1732,14 @@ impl<L> AutoCommandBufferBuilder<L> {
         shader_binding_table_addresses: ShaderBindingTableAddresses,
         indirect_buffer: Subbuffer<[TraceRaysIndirectCommand]>,
     ) -> Result<&mut Self, Box<ValidationError>> {
-        self.inner
-            .validate_trace_rays_indirect(&shader_binding_table_addresses, &indirect_buffer.buffer())?;
+        self.inner.validate_trace_rays_indirect(
+            &shader_binding_table_addresses,
+            &indirect_buffer.buffer(),
+        )?;
 
-        Ok(unsafe { self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_buffer) })
+        Ok(unsafe {
+            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_buffer)
+        })
     }
 
     #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
@@ -1733,7 +1755,12 @@ impl<L> AutoCommandBufferBuilder<L> {
         self.add_indirect_buffer_resources(&mut used_resources, indirect_buffer.as_bytes());
 
         self.add_command("trace_rays_indirect", used_resources, move |out| {
-            unsafe { out.trace_rays_indirect_unchecked(&shader_binding_table_addresses, indirect_buffer.buffer()) };
+            unsafe {
+                out.trace_rays_indirect_unchecked(
+                    &shader_binding_table_addresses,
+                    indirect_buffer.buffer(),
+                )
+            };
         });
 
         self

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1706,7 +1706,7 @@ impl RecordingCommandBuffer {
     pub(crate) fn validate_trace_rays_indirect(
         &self,
         _shader_binding_table_addresses: &ShaderBindingTableAddresses,
-        _indirect_device_address: DeviceAddress,
+        indirect_device_address: DeviceAddress,
     ) -> Result<(), Box<ValidationError>> {
         if !self
             .device()
@@ -1734,6 +1734,15 @@ impl RecordingCommandBuffer {
                     compute operations"
                     .into(),
                 vuids: &["VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-cmdpool"],
+                ..Default::default()
+            }));
+        }
+
+        if !indirect_device_address.is_multiple_of(4) {
+            return Err(Box::new(ValidationError {
+                context: "indirect_device_address".into(),
+                problem: "is not a multiple of 4".into(),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03634"],
                 ..Default::default()
             }));
         }

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1,7 +1,12 @@
 use crate::{
-    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanObject, buffer::{Buffer, BufferUsage}, command_buffer::{
-        DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand, DrawMeshTasksIndirectCommand, TraceRaysIndirectCommand, sys::RecordingCommandBuffer
-    }, device::{DeviceOwned, QueueFlags}, pipeline::ray_tracing::ShaderBindingTableAddresses
+    buffer::{Buffer, BufferUsage},
+    command_buffer::{
+        sys::RecordingCommandBuffer, DispatchIndirectCommand, DrawIndexedIndirectCommand,
+        DrawIndirectCommand, DrawMeshTasksIndirectCommand, TraceRaysIndirectCommand,
+    },
+    device::{DeviceOwned, QueueFlags},
+    pipeline::ray_tracing::ShaderBindingTableAddresses,
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanObject,
 };
 
 impl RecordingCommandBuffer {
@@ -1712,7 +1717,9 @@ impl RecordingCommandBuffer {
                 requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
                     "ray_tracing_pipeline_trace_rays_indirect",
                 )])]),
-                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-rayTracingPipelineTraceRaysIndirect-03637"],
+                vuids: &[
+                    "VUID-vkCmdTraceRaysIndirectKHR-rayTracingPipelineTraceRaysIndirect-03637",
+                ],
                 ..Default::default()
             }));
         }

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1680,24 +1680,30 @@ impl RecordingCommandBuffer {
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         buffer: &Buffer,
+        offset: DeviceSize,
     ) -> &mut Self {
-        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, buffer) }.unwrap()
+        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, buffer, offset) }
+            .unwrap()
     }
 
     pub unsafe fn try_trace_rays_indirect(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         buffer: &Buffer,
+        offset: DeviceSize,
     ) -> Result<&mut Self, Box<ValidationError>> {
-        self.validate_trace_rays_indirect(shader_binding_table_addresses, buffer)?;
+        self.validate_trace_rays_indirect(shader_binding_table_addresses, buffer, offset)?;
 
-        Ok(unsafe { self.trace_rays_indirect_unchecked(shader_binding_table_addresses, buffer) })
+        Ok(unsafe {
+            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, buffer, offset)
+        })
     }
 
     pub(crate) fn validate_trace_rays_indirect(
         &self,
         _shader_binding_table_addresses: &ShaderBindingTableAddresses,
         buffer: &Buffer,
+        offset: DeviceSize,
     ) -> Result<(), Box<ValidationError>> {
         if !self.device().enabled_features().ray_tracing_pipeline {
             return Err(Box::new(ValidationError {
@@ -1747,19 +1753,23 @@ impl RecordingCommandBuffer {
             }));
         }
 
-        if !buffer.device_address().get().is_multiple_of(4) {
+        if !offset.is_multiple_of(4) {
             return Err(Box::new(ValidationError {
-                context: "buffer.device_address()".into(),
+                context: "offset".into(),
                 problem: "is not a multiple of 4".into(),
                 vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03634"],
                 ..Default::default()
             }));
         }
 
-        if size_of::<TraceRaysIndirectCommand>() as DeviceSize > buffer.size() {
+        if offset
+            .checked_add(size_of::<TraceRaysIndirectCommand>() as DeviceSize)
+            .is_none_or(|end| end > buffer.size())
+        {
             return Err(Box::new(ValidationError {
-                context: "buffer.size()".into(),
-                problem: "is less than `size_of::<TraceRaysIndirectCommand>()`".into(),
+                problem: "`offset + size_of::<TraceRaysIndirectCommand>()` is greater than \
+                    `buffer.size()`"
+                    .into(),
                 vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03636"],
                 ..Default::default()
             }));
@@ -1773,6 +1783,7 @@ impl RecordingCommandBuffer {
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         buffer: &Buffer,
+        offset: DeviceSize,
     ) -> &mut Self {
         let raygen = shader_binding_table_addresses.raygen.to_vk();
         let miss = shader_binding_table_addresses.miss.to_vk();
@@ -1788,7 +1799,7 @@ impl RecordingCommandBuffer {
                 &miss,
                 &hit,
                 &callable,
-                buffer.device_address().into(),
+                buffer.device_address().get() + offset,
             )
         };
 

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1,8 +1,10 @@
+use ash::vk::DeviceAddress;
+
 use crate::{
     buffer::{Buffer, BufferUsage},
     command_buffer::{
         sys::RecordingCommandBuffer, DispatchIndirectCommand, DrawIndexedIndirectCommand,
-        DrawIndirectCommand, DrawMeshTasksIndirectCommand, TraceRaysIndirectCommand,
+        DrawIndirectCommand, DrawMeshTasksIndirectCommand,
     },
     device::{DeviceOwned, QueueFlags},
     pipeline::ray_tracing::ShaderBindingTableAddresses,
@@ -1679,31 +1681,28 @@ impl RecordingCommandBuffer {
     pub unsafe fn trace_rays_indirect(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
-        buffer: &Buffer,
-        offset: DeviceSize,
+        indirect_device_address: DeviceAddress,
     ) -> &mut Self {
-        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, buffer, offset) }
+        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, indirect_device_address) }
             .unwrap()
     }
 
     pub unsafe fn try_trace_rays_indirect(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
-        buffer: &Buffer,
-        offset: DeviceSize,
+        indirect_device_address: DeviceAddress,
     ) -> Result<&mut Self, Box<ValidationError>> {
-        self.validate_trace_rays_indirect(shader_binding_table_addresses, buffer, offset)?;
+        self.validate_trace_rays_indirect(shader_binding_table_addresses, indirect_device_address)?;
 
         Ok(unsafe {
-            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, buffer, offset)
+            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_device_address)
         })
     }
 
     pub(crate) fn validate_trace_rays_indirect(
         &self,
         _shader_binding_table_addresses: &ShaderBindingTableAddresses,
-        buffer: &Buffer,
-        offset: DeviceSize,
+        _indirect_device_address: DeviceAddress,
     ) -> Result<(), Box<ValidationError>> {
         if !self.device().enabled_features().ray_tracing_pipeline {
             return Err(Box::new(ValidationError {
@@ -1744,37 +1743,6 @@ impl RecordingCommandBuffer {
             }));
         }
 
-        if !buffer.usage().intersects(BufferUsage::INDIRECT_BUFFER) {
-            return Err(Box::new(ValidationError {
-                context: "buffer.usage()".into(),
-                problem: "does not contain `BufferUsage::INDIRECT_BUFFER`".into(),
-                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03633"],
-                ..Default::default()
-            }));
-        }
-
-        if !offset.is_multiple_of(4) {
-            return Err(Box::new(ValidationError {
-                context: "offset".into(),
-                problem: "is not a multiple of 4".into(),
-                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03634"],
-                ..Default::default()
-            }));
-        }
-
-        if offset
-            .checked_add(size_of::<TraceRaysIndirectCommand>() as DeviceSize)
-            .is_none_or(|end| end > buffer.size())
-        {
-            return Err(Box::new(ValidationError {
-                problem: "`offset + size_of::<TraceRaysIndirectCommand>()` is greater than \
-                    `buffer.size()`"
-                    .into(),
-                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03636"],
-                ..Default::default()
-            }));
-        }
-
         Ok(())
     }
 
@@ -1782,8 +1750,7 @@ impl RecordingCommandBuffer {
     pub unsafe fn trace_rays_indirect_unchecked(
         &mut self,
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
-        buffer: &Buffer,
-        offset: DeviceSize,
+        indirect_device_address: DeviceAddress,
     ) -> &mut Self {
         let raygen = shader_binding_table_addresses.raygen.to_vk();
         let miss = shader_binding_table_addresses.miss.to_vk();
@@ -1799,7 +1766,7 @@ impl RecordingCommandBuffer {
                 &miss,
                 &hit,
                 &callable,
-                buffer.device_address().get() + offset,
+                indirect_device_address,
             )
         };
 

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1,5 +1,3 @@
-use ash::vk::DeviceAddress;
-
 use crate::{
     buffer::{Buffer, BufferUsage},
     command_buffer::{
@@ -10,6 +8,7 @@ use crate::{
     pipeline::ray_tracing::ShaderBindingTableAddresses,
     DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanObject,
 };
+use ash::vk::DeviceAddress;
 
 impl RecordingCommandBuffer {
     #[inline]
@@ -1683,8 +1682,10 @@ impl RecordingCommandBuffer {
         shader_binding_table_addresses: &ShaderBindingTableAddresses,
         indirect_device_address: DeviceAddress,
     ) -> &mut Self {
-        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, indirect_device_address) }
-            .unwrap()
+        unsafe {
+            self.try_trace_rays_indirect(shader_binding_table_addresses, indirect_device_address)
+        }
+        .unwrap()
     }
 
     pub unsafe fn try_trace_rays_indirect(
@@ -1695,7 +1696,10 @@ impl RecordingCommandBuffer {
         self.validate_trace_rays_indirect(shader_binding_table_addresses, indirect_device_address)?;
 
         Ok(unsafe {
-            self.trace_rays_indirect_unchecked(shader_binding_table_addresses, indirect_device_address)
+            self.trace_rays_indirect_unchecked(
+                shader_binding_table_addresses,
+                indirect_device_address,
+            )
         })
     }
 

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1708,15 +1708,6 @@ impl RecordingCommandBuffer {
         _shader_binding_table_addresses: &ShaderBindingTableAddresses,
         _indirect_device_address: DeviceAddress,
     ) -> Result<(), Box<ValidationError>> {
-        if !self.device().enabled_features().ray_tracing_pipeline {
-            return Err(Box::new(ValidationError {
-                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
-                    "ray_tracing_pipeline",
-                )])]),
-                ..Default::default()
-            }));
-        }
-
         if !self
             .device()
             .enabled_features()

--- a/vulkano/src/command_buffer/commands/pipeline.rs
+++ b/vulkano/src/command_buffer/commands/pipeline.rs
@@ -1,12 +1,7 @@
 use crate::{
-    buffer::{Buffer, BufferUsage},
-    command_buffer::{
-        sys::RecordingCommandBuffer, DispatchIndirectCommand, DrawIndexedIndirectCommand,
-        DrawIndirectCommand, DrawMeshTasksIndirectCommand,
-    },
-    device::{DeviceOwned, QueueFlags},
-    pipeline::ray_tracing::ShaderBindingTableAddresses,
-    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanObject,
+    DeviceSize, Requires, RequiresAllOf, RequiresOneOf, ValidationError, Version, VulkanObject, buffer::{Buffer, BufferUsage}, command_buffer::{
+        DispatchIndirectCommand, DrawIndexedIndirectCommand, DrawIndirectCommand, DrawMeshTasksIndirectCommand, TraceRaysIndirectCommand, sys::RecordingCommandBuffer
+    }, device::{DeviceOwned, QueueFlags}, pipeline::ray_tracing::ShaderBindingTableAddresses
 };
 
 impl RecordingCommandBuffer {
@@ -1669,6 +1664,124 @@ impl RecordingCommandBuffer {
                 dimensions[0],
                 dimensions[1],
                 dimensions[2],
+            )
+        };
+
+        self
+    }
+
+    #[track_caller]
+    pub unsafe fn trace_rays_indirect(
+        &mut self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        buffer: &Buffer,
+    ) -> &mut Self {
+        unsafe { self.try_trace_rays_indirect(shader_binding_table_addresses, buffer) }.unwrap()
+    }
+
+    pub unsafe fn try_trace_rays_indirect(
+        &mut self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        buffer: &Buffer,
+    ) -> Result<&mut Self, Box<ValidationError>> {
+        self.validate_trace_rays_indirect(shader_binding_table_addresses, buffer)?;
+
+        Ok(unsafe { self.trace_rays_indirect_unchecked(shader_binding_table_addresses, buffer) })
+    }
+
+    pub(crate) fn validate_trace_rays_indirect(
+        &self,
+        _shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        buffer: &Buffer,
+    ) -> Result<(), Box<ValidationError>> {
+        if !self.device().enabled_features().ray_tracing_pipeline {
+            return Err(Box::new(ValidationError {
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
+                    "ray_tracing_pipeline",
+                )])]),
+                ..Default::default()
+            }));
+        }
+
+        if !self
+            .device()
+            .enabled_features()
+            .ray_tracing_pipeline_trace_rays_indirect
+        {
+            return Err(Box::new(ValidationError {
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceFeature(
+                    "ray_tracing_pipeline_trace_rays_indirect",
+                )])]),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-rayTracingPipelineTraceRaysIndirect-03637"],
+                ..Default::default()
+            }));
+        }
+
+        if !self
+            .queue_family_properties()
+            .queue_flags
+            .intersects(QueueFlags::COMPUTE)
+        {
+            return Err(Box::new(ValidationError {
+                problem: "the queue family of the command buffer does not support \
+                    compute operations"
+                    .into(),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-commandBuffer-cmdpool"],
+                ..Default::default()
+            }));
+        }
+
+        if !buffer.usage().intersects(BufferUsage::INDIRECT_BUFFER) {
+            return Err(Box::new(ValidationError {
+                context: "buffer.usage()".into(),
+                problem: "does not contain `BufferUsage::INDIRECT_BUFFER`".into(),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03633"],
+                ..Default::default()
+            }));
+        }
+
+        if !buffer.device_address().get().is_multiple_of(4) {
+            return Err(Box::new(ValidationError {
+                context: "buffer.device_address()".into(),
+                problem: "is not a multiple of 4".into(),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03634"],
+                ..Default::default()
+            }));
+        }
+
+        if size_of::<TraceRaysIndirectCommand>() as DeviceSize > buffer.size() {
+            return Err(Box::new(ValidationError {
+                context: "buffer.size()".into(),
+                problem: "is less than `size_of::<TraceRaysIndirectCommand>()`".into(),
+                vuids: &["VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03636"],
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    pub unsafe fn trace_rays_indirect_unchecked(
+        &mut self,
+        shader_binding_table_addresses: &ShaderBindingTableAddresses,
+        buffer: &Buffer,
+    ) -> &mut Self {
+        let raygen = shader_binding_table_addresses.raygen.to_vk();
+        let miss = shader_binding_table_addresses.miss.to_vk();
+        let hit = shader_binding_table_addresses.hit.to_vk();
+        let callable = shader_binding_table_addresses.callable.to_vk();
+
+        let fns = self.device().fns();
+
+        unsafe {
+            (fns.khr_ray_tracing_pipeline.cmd_trace_rays_indirect_khr)(
+                self.handle(),
+                &raygen,
+                &miss,
+                &hit,
+                &callable,
+                buffer.device_address().into(),
             )
         };
 

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -251,6 +251,27 @@ pub struct DrawIndexedIndirectCommand {
 unsafe impl Pod for DrawIndexedIndirectCommand {}
 unsafe impl Zeroable for DrawIndexedIndirectCommand {}
 
+/// Used as buffer contents to provide input for the
+/// [`AutoCommandBufferBuilder::trace_rays_indirect`] command.
+///
+/// # Safety
+///
+/// - The `width`, `height` and `depth` values must not exceed the product of the respective
+/// [`max_compute_work_group_count`](DeviceProperties::max_compute_work_group_count) and
+/// [`max_compute_work_group_size`](DeviceProperties::max_compute_work_group_size) elements.
+/// - `width` * `height` * `depth` must not exceed
+/// [`max_ray_dispatch_invocation_count`](RayTracingPipelineProperties::max_ray_dispatch_invocation_count).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TraceRaysIndirectCommand {
+    pub width: u32,
+    pub height: u32,
+    pub depth: u32,
+}
+
+unsafe impl Pod for TraceRaysIndirectCommand {}
+unsafe impl Zeroable for TraceRaysIndirectCommand {}
+
 vulkan_enum! {
     #[non_exhaustive]
 

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -257,7 +257,7 @@ unsafe impl Zeroable for DrawIndexedIndirectCommand {}
 /// # Safety
 ///
 /// - The `width`, `height` and `depth` values must not exceed the product of the respective
-/// [`max_compute_work_group_count`](DeviceProperties::max_compute_work_group_count) and
+/// [`max_compute_work_group_count`](DeviceProperties::max_compute_work_group_count) elements and
 /// [`max_compute_work_group_size`](DeviceProperties::max_compute_work_group_size) elements.
 /// - `width` * `height` * `depth` must not exceed
 /// [`max_ray_dispatch_invocation_count`](RayTracingPipelineProperties::max_ray_dispatch_invocation_count).

--- a/vulkano/src/command_buffer/mod.rs
+++ b/vulkano/src/command_buffer/mod.rs
@@ -257,10 +257,10 @@ unsafe impl Zeroable for DrawIndexedIndirectCommand {}
 /// # Safety
 ///
 /// - The `width`, `height` and `depth` values must not exceed the product of the respective
-/// [`max_compute_work_group_count`](DeviceProperties::max_compute_work_group_count) elements and
-/// [`max_compute_work_group_size`](DeviceProperties::max_compute_work_group_size) elements.
+///   [`max_compute_work_group_count`](DeviceProperties::max_compute_work_group_count) elements and
+///   [`max_compute_work_group_size`](DeviceProperties::max_compute_work_group_size) elements.
 /// - `width` * `height` * `depth` must not exceed
-/// [`max_ray_dispatch_invocation_count`](RayTracingPipelineProperties::max_ray_dispatch_invocation_count).
+///   [`max_ray_dispatch_invocation_count`](RayTracingPipelineProperties::max_ray_dispatch_invocation_count).
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct TraceRaysIndirectCommand {

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -1037,7 +1037,6 @@ impl FormatProperties {
         {
             let &vk::DrmFormatModifierPropertiesListEXT {
                 drm_format_modifier_count,
-                p_drm_format_modifier_properties: _,
                 ..
             } = list_vk;
 

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -1020,7 +1020,6 @@ impl FormatProperties {
         {
             let &vk::DrmFormatModifierPropertiesList2EXT {
                 drm_format_modifier_count,
-                p_drm_format_modifier_properties: _,
                 ..
             } = list_vk;
 


### PR DESCRIPTION
I've added the `trace_rays_indirect` and related functions to `RecordingCommandBuffer`. Its a bit strange that `cmd_trace_rays_indirect_khr` only takes a device address for the indirect command buffer and no offset, but everything else was pretty straightforward. Let me know if I missed anything in the docs or validation and I'll fix it.