### PR TITLE
Support for the `ext_memory_budget` device extension

### DIFF
--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     instance::{Instance, InstanceOwned},
     macros::{impl_id_counter, vulkan_bitflags, vulkan_enum},
-    memory::{ExternalMemoryHandleType, MemoryProperties},
+    memory::{ExternalMemoryHandleType, MemoryBudget, MemoryProperties},
     swapchain::{
         ColorSpace, FullScreenExclusive, PresentMode, Surface, SurfaceApi, SurfaceCapabilities,
         SurfaceInfo, SurfaceInfo2ExtensionsVk,
@@ -495,6 +495,79 @@ impl PhysicalDevice {
     #[inline]
     pub fn queue_family_properties(&self) -> &[QueueFamilyProperties] {
         &self.queue_family_properties
+    }
+
+    /// Retrieves the current memory budget and usage of each memory heap of the physical device,
+    /// panicking on a validation error.
+    ///
+    /// These properties may change during runtime, so the result only reflects the current
+    /// situation and is not cached.
+    ///
+    /// The [`ext_memory_budget`] extension must be supported by the physical device.
+    ///
+    /// This is a shortcut for `try_memory_budget().unwrap()`.
+    ///
+    /// # Panics
+    ///
+    /// - Panics if [`try_memory_budget`] returns a [`ValidationError`].
+    ///
+    /// [`ext_memory_budget`]: crate::device::DeviceExtensions::ext_memory_budget
+    /// [`try_memory_budget`]: Self::try_memory_budget
+    #[inline]
+    #[track_caller]
+    pub fn memory_budget(&self) -> MemoryBudget {
+        self.try_memory_budget().unwrap()
+    }
+
+    /// Retrieves the current memory budget and usage of each memory heap of the physical device.
+    ///
+    /// These properties may change during runtime, so the result only reflects the current
+    /// situation and is not cached.
+    ///
+    /// The [`ext_memory_budget`] extension must be supported by the physical device.
+    ///
+    /// [`ext_memory_budget`]: crate::device::DeviceExtensions::ext_memory_budget
+    #[inline]
+    pub fn try_memory_budget(&self) -> Result<MemoryBudget, Box<ValidationError>> {
+        self.validate_memory_budget()?;
+
+        Ok(unsafe { self.memory_budget_unchecked() })
+    }
+
+    fn validate_memory_budget(&self) -> Result<(), Box<ValidationError>> {
+        if !self.supported_extensions().ext_memory_budget {
+            return Err(Box::new(ValidationError {
+                requires_one_of: RequiresOneOf(&[RequiresAllOf(&[Requires::DeviceExtension(
+                    "ext_memory_budget",
+                )])]),
+                ..Default::default()
+            }));
+        }
+
+        Ok(())
+    }
+
+    #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+    #[inline]
+    pub unsafe fn memory_budget_unchecked(&self) -> MemoryBudget {
+        let mut budget_vk = MemoryBudget::to_mut_vk2();
+        let mut properties2_vk = MemoryProperties::to_mut_vk2().push_next(&mut budget_vk);
+
+        let fns = self.instance.fns();
+        if self.instance.api_version() >= Version::V1_1 {
+            unsafe {
+                (fns.v1_1.get_physical_device_memory_properties2)(self.handle, &mut properties2_vk)
+            };
+        } else {
+            unsafe {
+                (fns.khr_get_physical_device_properties2
+                    .get_physical_device_memory_properties2_khr)(
+                    self.handle, &mut properties2_vk
+                )
+            };
+        }
+
+        MemoryBudget::from_vk(&budget_vk, self.memory_properties().memory_heaps.len())
     }
 
     /// Returns the properties of displays attached to the physical device, panicking on a

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -503,7 +503,7 @@ impl PhysicalDevice {
     /// These properties may change during runtime, so the result only reflects the current
     /// situation and is not cached.
     ///
-    /// The [`ext_memory_budget`] extension must be enabled on the device.
+    /// The [`ext_memory_budget`] extension must be supported by the physical device.
     ///
     /// This is a shortcut for `try_memory_budget().unwrap()`.
     ///
@@ -524,7 +524,7 @@ impl PhysicalDevice {
     /// These properties may change during runtime, so the result only reflects the current
     /// situation and is not cached.
     ///
-    /// The [`ext_memory_budget`] extension must be enabled on the device.
+    /// The [`ext_memory_budget`] extension must be supported by the physical device.
     ///
     /// [`ext_memory_budget`]: crate::device::DeviceExtensions::ext_memory_budget
     #[inline]

--- a/vulkano/src/device/physical.rs
+++ b/vulkano/src/device/physical.rs
@@ -503,7 +503,7 @@ impl PhysicalDevice {
     /// These properties may change during runtime, so the result only reflects the current
     /// situation and is not cached.
     ///
-    /// The [`ext_memory_budget`] extension must be supported by the physical device.
+    /// The [`ext_memory_budget`] extension must be enabled on the device.
     ///
     /// This is a shortcut for `try_memory_budget().unwrap()`.
     ///
@@ -524,7 +524,7 @@ impl PhysicalDevice {
     /// These properties may change during runtime, so the result only reflects the current
     /// situation and is not cached.
     ///
-    /// The [`ext_memory_budget`] extension must be supported by the physical device.
+    /// The [`ext_memory_budget`] extension must be enabled on the device.
     ///
     /// [`ext_memory_budget`]: crate::device::DeviceExtensions::ext_memory_budget
     #[inline]

--- a/vulkano/src/format.rs
+++ b/vulkano/src/format.rs
@@ -1020,7 +1020,6 @@ impl FormatProperties {
         {
             let &vk::DrmFormatModifierPropertiesList2EXT {
                 drm_format_modifier_count,
-                p_drm_format_modifier_properties: _,
                 ..
             } = list_vk;
 
@@ -1037,7 +1036,6 @@ impl FormatProperties {
         {
             let &vk::DrmFormatModifierPropertiesListEXT {
                 drm_format_modifier_count,
-                p_drm_format_modifier_properties: _,
                 ..
             } = list_vk;
 

--- a/vulkano/src/memory/mod.rs
+++ b/vulkano/src/memory/mod.rs
@@ -778,6 +778,42 @@ vulkan_bitflags! {
     ]),
 }
 
+/// The current memory budget and usage of each memory heap of a physical device.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct MemoryBudget {
+    /// For each memory heap, an estimate of how much memory the process can allocate before
+    /// allocation is likely to fail or cause performance degradation. Indexed identically to
+    /// [`MemoryProperties::memory_heaps`].
+    pub heap_budget: Vec<DeviceSize>,
+
+    /// For each memory heap, an estimate of how much memory the process is currently using.
+    /// Indexed identically to [`MemoryProperties::memory_heaps`].
+    pub heap_usage: Vec<DeviceSize>,
+}
+
+impl MemoryBudget {
+    pub(crate) fn to_mut_vk2() -> vk::PhysicalDeviceMemoryBudgetPropertiesEXT<'static> {
+        vk::PhysicalDeviceMemoryBudgetPropertiesEXT::default()
+    }
+
+    pub(crate) fn from_vk(
+        val_vk: &vk::PhysicalDeviceMemoryBudgetPropertiesEXT<'_>,
+        memory_heap_count: usize,
+    ) -> Self {
+        let &vk::PhysicalDeviceMemoryBudgetPropertiesEXT {
+            heap_budget,
+            heap_usage,
+            ..
+        } = val_vk;
+
+        Self {
+            heap_budget: heap_budget[..memory_heap_count].to_vec(),
+            heap_usage: heap_usage[..memory_heap_count].to_vec(),
+        }
+    }
+}
+
 /// A memory heap in a physical device.
 #[derive(Clone, Debug)]
 #[non_exhaustive]


### PR DESCRIPTION
Added `memory_budget` and related functions to `PhysicalDevice` that return the `MemoryBudget` struct added inside `vulkano::memory`.