### PR TITLE
`vulkano_shader`: add unchecked `load` methods

### DIFF
--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -449,13 +449,16 @@ pub(super) fn reflect(
         spirv,
     };
 
-    let include_bytes = input_paths.into_iter().map(|s| {
-        quote! {
-            // Using `include_bytes` here ensures that changing the shader will force recompilation.
-            // The bytes themselves can be optimized out by the compiler as they are unused.
-            ::std::include_bytes!( #s )
-        }
-    });
+    let include_bytes: Vec<_> = input_paths
+        .into_iter()
+        .map(|s| {
+            quote! {
+                // Using `include_bytes` here ensures that changing the shader will force recompilation.
+                // The bytes themselves can be optimized out by the compiler as they are unused.
+                ::std::include_bytes!( #s )
+            }
+        })
+        .collect();
 
     let load_name = if shader.name.is_empty() {
         format_ident!("load")
@@ -463,6 +466,7 @@ pub(super) fn reflect(
         format_ident!("load_{}", shader.name.to_snake_case())
     };
     let try_load_name = format_ident!("try_{load_name}");
+    let load_unchecked_name = format_ident!("{load_name}_unchecked");
 
     let shader_code = quote! {
         /// Loads the shader as a `ShaderModule`, panicking on a validation error.
@@ -500,6 +504,28 @@ pub(super) fn reflect(
 
             unsafe {
                 ::vulkano::shader::ShaderModule::try_new(
+                    device,
+                    &::vulkano::shader::ShaderModuleCreateInfo::new(WORDS),
+                )
+            }
+        }
+
+        /// Loads the shader as a `ShaderModule`, skipping validation.
+        #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
+        #[allow(unsafe_code)]
+        #[inline]
+        pub unsafe fn #load_unchecked_name(
+            device: &::std::sync::Arc<::vulkano::device::Device>,
+        ) -> ::std::result::Result<
+            ::std::sync::Arc<::vulkano::shader::ShaderModule>,
+            ::vulkano::VulkanError,
+        > {
+            let _bytes = ( #( #include_bytes ),* );
+
+            static WORDS: &[u32] = &[ #( #words ),* ];
+
+            unsafe {
+                ::vulkano::shader::ShaderModule::new_unchecked(
                     device,
                     &::vulkano::shader::ShaderModuleCreateInfo::new(WORDS),
                 )

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -449,16 +449,13 @@ pub(super) fn reflect(
         spirv,
     };
 
-    let include_bytes: Vec<_> = input_paths
-        .into_iter()
-        .map(|s| {
-            quote! {
-                // Using `include_bytes` here ensures that changing the shader will force recompilation.
-                // The bytes themselves can be optimized out by the compiler as they are unused.
-                ::std::include_bytes!( #s )
-            }
-        })
-        .collect();
+    let include_bytes = input_paths.into_iter().map(|s| {
+        quote! {
+            // Using `include_bytes` here ensures that changing the shader will force recompilation.
+            // The bytes themselves can be optimized out by the compiler as they are unused.
+            ::std::include_bytes!( #s )
+        }
+    });
 
     let load_name = if shader.name.is_empty() {
         format_ident!("load")
@@ -467,8 +464,13 @@ pub(super) fn reflect(
     };
     let try_load_name = format_ident!("try_{load_name}");
     let load_unchecked_name = format_ident!("{load_name}_unchecked");
+    let words_name = format_ident!("{}_WORDS", load_name.to_string().to_uppercase());
 
     let shader_code = quote! {
+        const _: &[&[u8]] = &[ #( #include_bytes ),* ];
+
+        static #words_name: &[u32] = &[ #( #words ),* ];
+
         /// Loads the shader as a `ShaderModule`, panicking on a validation error.
         #[allow(unsafe_code)]
         #[inline]
@@ -498,14 +500,10 @@ pub(super) fn reflect(
             ::std::sync::Arc<::vulkano::shader::ShaderModule>,
             ::vulkano::Validated<::vulkano::VulkanError>,
         > {
-            let _bytes = ( #( #include_bytes ),* );
-
-            static WORDS: &[u32] = &[ #( #words ),* ];
-
             unsafe {
                 ::vulkano::shader::ShaderModule::try_new(
                     device,
-                    &::vulkano::shader::ShaderModuleCreateInfo::new(WORDS),
+                    &::vulkano::shader::ShaderModuleCreateInfo::new(#words_name),
                 )
             }
         }
@@ -519,14 +517,10 @@ pub(super) fn reflect(
             ::std::sync::Arc<::vulkano::shader::ShaderModule>,
             ::vulkano::VulkanError,
         > {
-            let _bytes = ( #( #include_bytes ),* );
-
-            static WORDS: &[u32] = &[ #( #words ),* ];
-
             unsafe {
                 ::vulkano::shader::ShaderModule::new_unchecked(
                     device,
-                    &::vulkano::shader::ShaderModuleCreateInfo::new(WORDS),
+                    &::vulkano::shader::ShaderModuleCreateInfo::new(#words_name),
                 )
             }
         }

--- a/vulkano-shaders/src/codegen.rs
+++ b/vulkano-shaders/src/codegen.rs
@@ -511,7 +511,6 @@ pub(super) fn reflect(
         }
 
         /// Loads the shader as a `ShaderModule`, skipping validation.
-        #[cfg_attr(not(feature = "document_unchecked"), doc(hidden))]
         #[allow(unsafe_code)]
         #[inline]
         pub unsafe fn #load_unchecked_name(

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -46,8 +46,8 @@
 //!   `Result<Arc<ShaderModule>, VulkanError>`. It also generates the `try_load` function, which
 //!   works the same, but returns a `Result<Arc<ShaderModule>, Validated<VulkanError>>`. These
 //!   functions are both unsafe because they delegate to the unsafe [`ShaderModule::try_new`].
-//!   Additionally, a `load_unchecked` function is generated, which skips validation entirely
-//!   and delegates to [`ShaderModule::new_unchecked`].
+//!   Additionally, a `load_unchecked` function is generated, which skips validation entirely and
+//!   delegates to [`ShaderModule::new_unchecked`].
 //! - If the `shaders` option is used, then instead of one `load` constructor, there is one for
 //!   each shader. They are named based on the provided names, `load_first`, `load_second` etc.
 //!   `try_` and `_unchecked` variants are also generated for each shader.

--- a/vulkano-shaders/src/lib.rs
+++ b/vulkano-shaders/src/lib.rs
@@ -46,8 +46,11 @@
 //!   `Result<Arc<ShaderModule>, VulkanError>`. It also generates the `try_load` function, which
 //!   works the same, but returns a `Result<Arc<ShaderModule>, Validated<VulkanError>>`. These
 //!   functions are both unsafe because they delegate to the unsafe [`ShaderModule::try_new`].
+//!   Additionally, a `load_unchecked` function is generated, which skips validation entirely
+//!   and delegates to [`ShaderModule::new_unchecked`].
 //! - If the `shaders` option is used, then instead of one `load` constructor, there is one for
 //!   each shader. They are named based on the provided names, `load_first`, `load_second` etc.
+//!   `try_` and `_unchecked` variants are also generated for each shader.
 //! - A Rust struct translated from each struct contained in the shader data. By default, each
 //!   structure has a `Clone` and a `Copy` implementation. This behavior could be customized
 //!   through the `custom_derives` macro option (see below for details). Each struct also has an


### PR DESCRIPTION
This is to circumvent `Slang` reporting SPIR-V capabilities not yet regognised by `vulkano`. The specific case I came across was `SPV_KHR_compute_shader_derivatives` where associated functions can be used anyway via `VK_NV_compute_shader_derivatives` and associated features.

1. [x] Update documentation to reflect any user-facing changes - in this repository.

2. [ ] Make sure that the changes are covered by unit-tests.

3. [x] Run `cargo clippy` on the changes.

4. [x] Run `cargo +nightly fmt` on the changes.