### PR TITLE
Optimize the suballocation lists

### DIFF
--- a/vulkano/src/memory/allocator/suballocator/buddy.rs
+++ b/vulkano/src/memory/allocator/suballocator/buddy.rs
@@ -101,38 +101,27 @@ unsafe impl Suballocator for BuddyAllocator {
         assert!(region.size().is_power_of_two());
         assert!(region.size() >= BuddyAllocator::MIN_NODE_SIZE);
 
+        // The division can't discard any bits because `region.size()` is a power of two.
         let max_order = (region.size() / BuddyAllocator::MIN_NODE_SIZE).trailing_zeros() as usize;
 
         assert!(max_order < BuddyAllocator::MAX_ORDERS);
 
-        let node_allocator = slabbin::SlabAllocator::new(32);
-        let root_ptr = node_allocator.allocate();
-        // The root node has the lowest offset and highest order, so it's the whole region.
-        let root = SuballocationTreeNode {
-            parent_ptr: NonNull::dangling(),
-            ty: NodeType::new_leaf(Leaf {
-                tag: NodeTag::Leaf,
-                prev_ptr: None,
-                next_ptr: None,
-                compressed_offset: 0,
-                order: max_order as u8,
-                allocation_type: SuballocationType::Free,
-            }),
-        };
-        unsafe { root_ptr.write(root) };
-
         // This can't overflow because `max_order` is less than `BuddyAllocator::MAX_ORDERS`.
         let orders = max_order + 1;
-        let mut free_list = ArrayVec::new(orders, [EMPTY_FREE_LIST; BuddyAllocator::MAX_ORDERS]);
-        free_list[max_order].push(root_ptr);
 
-        let suballocations = SuballocationTree {
+        let mut suballocations = SuballocationTree {
             region,
-            root_ptr,
-            len: 1,
-            free_list,
-            node_allocator,
+            root_ptr: NonNull::dangling(),
+            head_ptr: NonNull::dangling(),
+            tail_ptr: NonNull::dangling(),
+            len: 0,
+            free_list: ArrayVec::new(orders, [EMPTY_FREE_LIST; BuddyAllocator::MAX_ORDERS]),
+            node_allocator: slabbin::SlabAllocator::new(32),
         };
+
+        // This can't discard any bits because `max_order` is confined to the range
+        // [0, BuddyAllocator::MAX_ORDERS).
+        unsafe { suballocations.init(max_order as u8) };
 
         BuddyAllocator {
             free_size: region.size(),
@@ -265,6 +254,8 @@ impl BuddyAllocator {
 struct SuballocationTree {
     region: Region,
     root_ptr: NonNull<SuballocationTreeNode>,
+    head_ptr: NonNull<SuballocationTreeNode>,
+    tail_ptr: NonNull<SuballocationTreeNode>,
     len: usize,
     // Every order has its own free-list. Each free-list is sorted by offset because we want to
     // find the first-fit as this strategy minimizes external fragmentation.
@@ -295,9 +286,9 @@ struct Leaf {
     /// ensures that the offset fits in a `u32`, otherwise `Self` would be wider by a `DeviceSize`.
     compressed_offset: u32,
     /// The previous leaf node.
-    prev_ptr: Option<NonNull<SuballocationTreeNode>>,
+    prev_ptr: NonNull<SuballocationTreeNode>,
     /// The next leaf node.
-    next_ptr: Option<NonNull<SuballocationTreeNode>>,
+    next_ptr: NonNull<SuballocationTreeNode>,
 }
 
 #[derive(Clone, Copy)]
@@ -321,6 +312,61 @@ unsafe impl Send for SuballocationTree {}
 unsafe impl Sync for SuballocationTree {}
 
 impl SuballocationTree {
+    unsafe fn init(&mut self, max_order: u8) {
+        let head_ptr = self.node_allocator.allocate();
+        let root_ptr = self.node_allocator.allocate();
+        let tail_ptr = self.node_allocator.allocate();
+
+        let head = SuballocationTreeNode {
+            parent_ptr: NonNull::dangling(),
+            ty: NodeType::new_leaf(Leaf {
+                tag: NodeTag::Leaf,
+                prev_ptr: NonNull::dangling(),
+                next_ptr: root_ptr,
+                compressed_offset: 0,
+                order: 0,
+                allocation_type: SuballocationType::Unknown,
+            }),
+        };
+        unsafe { head_ptr.write(head) };
+
+        // The root node has the lowest offset and highest order, so it's the whole region.
+        let root = SuballocationTreeNode {
+            parent_ptr: NonNull::dangling(),
+            ty: NodeType::new_leaf(Leaf {
+                tag: NodeTag::Leaf,
+                prev_ptr: head_ptr,
+                next_ptr: tail_ptr,
+                compressed_offset: 0,
+                order: max_order,
+                allocation_type: SuballocationType::Free,
+            }),
+        };
+        unsafe { root_ptr.write(root) };
+
+        let tail = SuballocationTreeNode {
+            parent_ptr: NonNull::dangling(),
+            ty: NodeType::new_leaf(Leaf {
+                tag: NodeTag::Leaf,
+                prev_ptr: root_ptr,
+                next_ptr: NonNull::dangling(),
+                // The division can't discard any bits because the region size is a power of two.
+                // The cast can't discard any bits because the region size is at most `1 << 35`,
+                // and `(1 << 35) / BuddyAllocator::MIN_NODE_SIZE` is `1 << 31`.
+                compressed_offset: (self.region.size() / BuddyAllocator::MIN_NODE_SIZE) as u32,
+                order: 0,
+                allocation_type: SuballocationType::Unknown,
+            }),
+        };
+        unsafe { tail_ptr.write(tail) };
+
+        self.root_ptr = root_ptr;
+        self.head_ptr = head_ptr;
+        self.tail_ptr = tail_ptr;
+        self.len = 1;
+        self.free_list[usize::from(max_order)].push(root_ptr);
+    }
+
     #[inline]
     unsafe fn allocate(
         &mut self,
@@ -353,7 +399,7 @@ impl SuballocationTree {
             }
         };
 
-        let prev_ptr = node_ty.prev_ptr;
+        let mut prev_ptr = node_ty.prev_ptr;
         let mut next_ptr = node_ty.next_ptr;
         let compressed_offset = node_ty.compressed_offset;
 
@@ -379,7 +425,7 @@ impl SuballocationTree {
                 ty: NodeType::new_leaf(Leaf {
                     tag: NodeTag::Leaf,
                     prev_ptr,
-                    next_ptr: Some(right_ptr),
+                    next_ptr: right_ptr,
                     compressed_offset,
                     // This can't discard any bits because `order` is confined to the range
                     // [0, BuddyAllocator::MAX_ORDERS).
@@ -393,7 +439,7 @@ impl SuballocationTree {
                 parent_ptr: node_ptr,
                 ty: NodeType::new_leaf(Leaf {
                     tag: NodeTag::Leaf,
-                    prev_ptr: Some(left_ptr),
+                    prev_ptr: left_ptr,
                     next_ptr,
                     // The division can't discard any bits because sizes are aligned to
                     // `BuddyAllocator::MIN_NODE_SIZE`. The cast can't discard any bits because the
@@ -410,12 +456,10 @@ impl SuballocationTree {
             };
             unsafe { right_ptr.write(right) };
 
-            if let Some(mut next_ptr) = next_ptr {
-                let next = unsafe { next_ptr.as_mut() };
+            let next = unsafe { next_ptr.as_mut() };
 
-                // SAFETY: The list of leaf nodes only contains leaf nodes.
-                unsafe { next.ty.leaf_unchecked_mut() }.prev_ptr = Some(right_ptr);
-            }
+            // SAFETY: The list of leaf nodes only contains leaf nodes.
+            unsafe { next.ty.leaf_unchecked_mut() }.prev_ptr = right_ptr;
 
             unsafe { node_ptr.as_mut() }.ty = NodeType::new_branch(Branch {
                 tag: NodeTag::Branch,
@@ -426,19 +470,17 @@ impl SuballocationTree {
             self.len += 1;
 
             node_ptr = left_ptr;
-            next_ptr = Some(right_ptr);
+            next_ptr = right_ptr;
 
             unsafe { add_to_free_list(free_list, right_ptr, compressed_offset) };
 
             // Repeat splitting for the left child if required in the next loop turn.
         }
 
-        if let Some(mut prev_ptr) = prev_ptr {
-            let prev = unsafe { prev_ptr.as_mut() };
+        let prev = unsafe { prev_ptr.as_mut() };
 
-            // SAFETY: The list of leaf nodes only contains leaf nodes.
-            unsafe { prev.ty.leaf_unchecked_mut() }.next_ptr = Some(node_ptr);
-        }
+        // SAFETY: The list of leaf nodes only contains leaf nodes.
+        unsafe { prev.ty.leaf_unchecked_mut() }.next_ptr = node_ptr;
 
         Some((node_ptr, offset, min_order))
     }
@@ -569,41 +611,19 @@ impl SuballocationTree {
         // `log((1 << 35) / BuddyAllocator::MIN_NODE_SIZE)` is 31.
         let max_order = (self.region.size() / BuddyAllocator::MIN_NODE_SIZE).trailing_zeros() as u8;
 
-        let root_ptr = self.node_allocator.allocate();
-        let root = SuballocationTreeNode {
-            parent_ptr: NonNull::dangling(),
-            ty: NodeType::new_leaf(Leaf {
-                tag: NodeTag::Leaf,
-                prev_ptr: None,
-                next_ptr: None,
-                compressed_offset: 0,
-                order: max_order,
-                allocation_type: SuballocationType::Free,
-            }),
-        };
-        unsafe { root_ptr.write(root) };
-
-        self.root_ptr = root_ptr;
-        self.len = 1;
-        self.free_list[usize::from(max_order)].push(root_ptr);
+        unsafe { self.init(max_order) };
     }
 
     fn iter(&self) -> Suballocations<'_> {
-        let mut left_ptr = self.root_ptr;
-        let mut right_ptr = self.root_ptr;
-
-        while let Some(node_ty) = unsafe { left_ptr.as_ref() }.ty.branch() {
-            left_ptr = node_ty.left_ptr;
-        }
-
-        while let Some(node_ty) = unsafe { right_ptr.as_ref() }.ty.branch() {
-            right_ptr = node_ty.right_ptr;
-        }
+        let head = unsafe { self.head_ptr.as_ref() };
+        let tail = unsafe { self.tail_ptr.as_ref() };
+        let head_ptr = unsafe { head.ty.leaf_unchecked() }.next_ptr;
+        let tail_ptr = unsafe { tail.ty.leaf_unchecked() }.prev_ptr;
 
         Suballocations {
             region_offset: self.region.offset(),
-            left_ptr: Some(left_ptr),
-            right_ptr: Some(right_ptr),
+            head_ptr,
+            tail_ptr,
             len: self.len,
             marker: PhantomData,
         }
@@ -785,8 +805,8 @@ impl Leaf {
 #[derive(Clone)]
 pub struct Suballocations<'a> {
     region_offset: DeviceSize,
-    left_ptr: Option<NonNull<SuballocationTreeNode>>,
-    right_ptr: Option<NonNull<SuballocationTreeNode>>,
+    head_ptr: NonNull<SuballocationTreeNode>,
+    tail_ptr: NonNull<SuballocationTreeNode>,
     len: usize,
     marker: PhantomData<&'a SuballocationTree>,
 }
@@ -800,24 +820,20 @@ impl Iterator for Suballocations<'_> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.len != 0 {
-            if let Some(left_ptr) = self.left_ptr {
-                let node = unsafe { left_ptr.as_ref() };
+            let head = unsafe { self.head_ptr.as_ref() };
 
-                // SAFETY: We start out with `self.left_ptr` being a leaf node, and upon iteration,
-                // we set it to the next leaf node.
-                let node_ty = unsafe { node.ty.leaf_unchecked() };
+            // SAFETY: We start out with `self.left_ptr` being a leaf node, and upon iteration, we
+            // set it to the next leaf node.
+            let head_ty = unsafe { head.ty.leaf_unchecked() };
 
-                self.left_ptr = node_ty.next_ptr;
-                self.len -= 1;
+            self.head_ptr = head_ty.next_ptr;
+            self.len -= 1;
 
-                Some(SuballocationNode {
-                    offset: node_ty.offset(self.region_offset),
-                    size: BuddyAllocator::MIN_NODE_SIZE << node_ty.order,
-                    allocation_type: node_ty.allocation_type,
-                })
-            } else {
-                None
-            }
+            Some(SuballocationNode {
+                offset: head_ty.offset(self.region_offset),
+                size: BuddyAllocator::MIN_NODE_SIZE << head_ty.order,
+                allocation_type: head_ty.allocation_type,
+            })
         } else {
             None
         }
@@ -843,24 +859,20 @@ impl DoubleEndedIterator for Suballocations<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.len != 0 {
-            if let Some(right_ptr) = self.right_ptr {
-                let node = unsafe { right_ptr.as_ref() };
+            let tail = unsafe { self.tail_ptr.as_ref() };
 
-                // SAFETY: We start out with `self.right_ptr` being a leaf node, and upon
-                // iteration, we set it to the previous leaf node.
-                let node_ty = unsafe { node.ty.leaf_unchecked() };
+            // SAFETY: We start out with `self.right_ptr` being a leaf node, and upon iteration, we
+            // set it to the previous leaf node.
+            let tail_ty = unsafe { tail.ty.leaf_unchecked() };
 
-                self.right_ptr = node_ty.prev_ptr;
-                self.len -= 1;
+            self.tail_ptr = tail_ty.prev_ptr;
+            self.len -= 1;
 
-                Some(SuballocationNode {
-                    offset: node_ty.offset(self.region_offset),
-                    size: BuddyAllocator::MIN_NODE_SIZE << node_ty.order,
-                    allocation_type: node_ty.allocation_type,
-                })
-            } else {
-                None
-            }
+            Some(SuballocationNode {
+                offset: tail_ty.offset(self.region_offset),
+                size: BuddyAllocator::MIN_NODE_SIZE << tail_ty.order,
+                allocation_type: tail_ty.allocation_type,
+            })
         } else {
             None
         }

--- a/vulkano/src/memory/allocator/suballocator/free_list.rs
+++ b/vulkano/src/memory/allocator/suballocator/free_list.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     DeviceSize,
 };
-use std::{cmp, iter::FusedIterator, marker::PhantomData, ptr::NonNull};
+use std::{cmp, hint, iter::FusedIterator, marker::PhantomData, ptr::NonNull};
 
 /// A [suballocator] that uses the most generic [free-list].
 ///
@@ -62,7 +62,6 @@ use std::{cmp, iter::FusedIterator, marker::PhantomData, ptr::NonNull};
 /// [alignment requirements]: super::super#alignment
 #[derive(Debug)]
 pub struct FreeListAllocator {
-    region: Region,
     // Total memory remaining in the region.
     free_size: DeviceSize,
     suballocations: SuballocationList,
@@ -78,27 +77,27 @@ unsafe impl Suballocator for FreeListAllocator {
         let node_allocator = slabbin::SlabAllocator::<SuballocationListNode>::new(32);
         let root_ptr = node_allocator.allocate();
         let root = SuballocationListNode {
-            prev: None,
-            next: None,
+            prev_ptr: None,
+            next_ptr: None,
             offset: region.offset(),
             size: region.size(),
             allocation_type: SuballocationType::Free,
         };
-        unsafe { root_ptr.as_ptr().write(root) };
+        unsafe { root_ptr.write(root) };
 
         let mut free_list = Vec::with_capacity(32);
         free_list.push(root_ptr);
 
         let suballocations = SuballocationList {
-            head: root_ptr,
-            tail: root_ptr,
+            region,
+            head_ptr: root_ptr,
+            tail_ptr: root_ptr,
             len: 1,
             free_list,
             node_allocator,
         };
 
         FreeListAllocator {
-            region,
             free_size: region.size(),
             suballocations,
         }
@@ -125,15 +124,15 @@ unsafe impl Suballocator for FreeListAllocator {
         let alignment = layout.alignment();
 
         match self.suballocations.free_list.last() {
-            Some(&last) if unsafe { (*last.as_ptr()).size } >= size => {
+            Some(&last) if unsafe { last.as_ref() }.size >= size => {
                 // We create a dummy node to compare against in the below binary search. The only
                 // fields of importance are `offset` and `size`. It is paramount that we set
                 // `offset` to zero, so that in the case where there are multiple free
                 // suballocations with the same size, we get the first one of them, that is, the
                 // one with the lowest offset.
                 let dummy_node = SuballocationListNode {
-                    prev: None,
-                    next: None,
+                    prev_ptr: None,
+                    next_ptr: None,
                     offset: 0,
                     size,
                     allocation_type: SuballocationType::Unknown,
@@ -152,22 +151,22 @@ unsafe impl Suballocator for FreeListAllocator {
                 let (Ok(index) | Err(index)) = self
                     .suballocations
                     .free_list
-                    .binary_search_by_key(&dummy_node, |&ptr| unsafe { *ptr.as_ptr() });
+                    .binary_search_by_key(&&dummy_node, |&ptr| unsafe { ptr.as_ref() });
 
-                for (index, &node_ptr) in
+                for (index, &(mut node_ptr)) in
                     self.suballocations.free_list.iter().enumerate().skip(index)
                 {
-                    let node = unsafe { *node_ptr.as_ptr() };
+                    let node = unsafe { node_ptr.as_ref() };
 
                     // This can't overflow because suballocation offsets are bounded by the region,
                     // whose end can itself not exceed `DeviceLayout::MAX_SIZE`.
                     let mut offset = align_up(node.offset, alignment);
 
                     if buffer_image_granularity != DeviceAlignment::MIN {
-                        debug_assert!(is_aligned(self.region.offset(), buffer_image_granularity));
+                        debug_assert!(is_aligned(self.region().offset(), buffer_image_granularity));
 
-                        if let Some(prev_ptr) = node.prev {
-                            let prev = unsafe { *prev_ptr.as_ptr() };
+                        if let Some(prev_ptr) = node.prev_ptr {
+                            let prev = unsafe { prev_ptr.as_ref() };
 
                             if are_blocks_on_same_page(
                                 prev.offset,
@@ -194,11 +193,13 @@ unsafe impl Suballocator for FreeListAllocator {
 
                         // SAFETY:
                         // - `node` is free.
+                        // - We have removed `node` from the free-list.
                         // - `offset` is that of `node`, possibly rounded up.
                         // - We checked that `offset + size` falls within `node`.
                         unsafe { self.suballocations.split(node_ptr, offset, size) };
 
-                        unsafe { (*node_ptr.as_ptr()).allocation_type = allocation_type.into() };
+                        let node = unsafe { node_ptr.as_mut() };
+                        node.allocation_type = allocation_type.into();
 
                         // This can't overflow because suballocation sizes in the free-list are
                         // constrained by the remaining size of the region.
@@ -235,11 +236,11 @@ unsafe impl Suballocator for FreeListAllocator {
         // SAFETY: The caller must guarantee that `suballocation` refers to a currently allocated
         // allocation of `self`, which means that `node_ptr` is the same one we gave out on
         // allocation, making it a valid pointer.
-        let node_ptr = unsafe { NonNull::new_unchecked(node_ptr) };
+        let mut node_ptr = unsafe { NonNull::new_unchecked(node_ptr) };
 
         debug_assert!(self.suballocations.node_allocator.contains(node_ptr));
 
-        let node = unsafe { *node_ptr.as_ptr() };
+        let node = unsafe { node_ptr.as_mut() };
 
         debug_assert_ne!(node.allocation_type, SuballocationType::Free);
 
@@ -247,31 +248,15 @@ unsafe impl Suballocator for FreeListAllocator {
         // overflow when added up.
         self.free_size += node.size;
 
-        unsafe { (*node_ptr.as_ptr()).allocation_type = SuballocationType::Free };
+        node.allocation_type = SuballocationType::Free;
 
         unsafe { self.suballocations.coalesce(node_ptr) };
-        unsafe { self.suballocations.deallocate(node_ptr) };
+        unsafe { self.suballocations.add_to_free_list(node_ptr) };
     }
 
     fn reset(&mut self) {
-        self.free_size = self.region.size();
-        self.suballocations.free_list.clear();
-        unsafe { self.suballocations.node_allocator.reset() };
-
-        let root_ptr = self.suballocations.node_allocator.allocate();
-        let root = SuballocationListNode {
-            prev: None,
-            next: None,
-            offset: self.region.offset(),
-            size: self.region.size(),
-            allocation_type: SuballocationType::Free,
-        };
-        unsafe { root_ptr.as_ptr().write(root) };
-
-        self.suballocations.head = root_ptr;
-        self.suballocations.tail = root_ptr;
-        self.suballocations.len = 1;
-        self.suballocations.free_list.push(root_ptr);
+        self.suballocations.reset();
+        self.free_size = self.region().size();
     }
 
     #[inline]
@@ -285,10 +270,18 @@ unsafe impl Suballocator for FreeListAllocator {
     }
 }
 
+impl FreeListAllocator {
+    #[inline]
+    fn region(&self) -> &Region {
+        &self.suballocations.region
+    }
+}
+
 #[derive(Debug)]
 struct SuballocationList {
-    head: NonNull<SuballocationListNode>,
-    tail: NonNull<SuballocationListNode>,
+    region: Region,
+    head_ptr: NonNull<SuballocationListNode>,
+    tail_ptr: NonNull<SuballocationListNode>,
     len: usize,
     // Free suballocations sorted by size in ascending order. This means we can always find a
     // best-fit in *O*(log(*n*)) time in the worst case, and iterating in order is very efficient.
@@ -301,36 +294,11 @@ unsafe impl Sync for SuballocationList {}
 
 #[derive(Clone, Copy, Debug)]
 struct SuballocationListNode {
-    prev: Option<NonNull<Self>>,
-    next: Option<NonNull<Self>>,
+    prev_ptr: Option<NonNull<Self>>,
+    next_ptr: Option<NonNull<Self>>,
     offset: DeviceSize,
     size: DeviceSize,
     allocation_type: SuballocationType,
-}
-
-impl PartialEq for SuballocationListNode {
-    fn eq(&self, other: &Self) -> bool {
-        self.size == other.size && self.offset == other.offset
-    }
-}
-
-impl Eq for SuballocationListNode {}
-
-impl PartialOrd for SuballocationListNode {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for SuballocationListNode {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        // We want to sort the free-list by size.
-        self.size
-            .cmp(&other.size)
-            // However there might be multiple free suballocations with the same size, so we need
-            // to compare the offset as well to differentiate.
-            .then(self.offset.cmp(&other.offset))
-    }
 }
 
 impl SuballocationList {
@@ -339,16 +307,19 @@ impl SuballocationList {
     /// # Safety
     ///
     /// - `node_ptr` must refer to a currently free suballocation of `self`.
+    /// - `node_ptr` must have been removed from the free-list.
     /// - `offset` and `size` must refer to a subregion of the given suballocation.
+    #[inline]
     unsafe fn split(
         &mut self,
-        node_ptr: NonNull<SuballocationListNode>,
+        mut node_ptr: NonNull<SuballocationListNode>,
         offset: DeviceSize,
         size: DeviceSize,
     ) {
-        let node = unsafe { *node_ptr.as_ptr() };
+        let node = unsafe { node_ptr.as_mut() };
 
         debug_assert_eq!(node.allocation_type, SuballocationType::Free);
+        debug_assert!(!self.free_list.contains(&node_ptr));
         debug_assert!(offset >= node.offset);
         debug_assert!(offset + size <= node.offset + node.size);
 
@@ -360,63 +331,65 @@ impl SuballocationList {
         if padding_front > 0 {
             let padding_ptr = self.node_allocator.allocate();
             let padding = SuballocationListNode {
-                prev: node.prev,
-                next: Some(node_ptr),
+                prev_ptr: node.prev_ptr,
+                next_ptr: Some(node_ptr),
                 offset: node.offset,
                 size: padding_front,
                 allocation_type: SuballocationType::Free,
             };
-            unsafe { padding_ptr.as_ptr().write(padding) };
+            unsafe { padding_ptr.write(padding) };
 
-            if let Some(prev_ptr) = padding.prev {
-                unsafe { (*prev_ptr.as_ptr()).next = Some(padding_ptr) };
+            if let Some(mut prev_ptr) = padding.prev_ptr {
+                let prev = unsafe { prev_ptr.as_mut() };
+                prev.next_ptr = Some(padding_ptr);
             }
 
-            unsafe { (*node_ptr.as_ptr()).prev = Some(padding_ptr) };
-            unsafe { (*node_ptr.as_ptr()).offset = offset };
+            node.prev_ptr = Some(padding_ptr);
+            node.offset = offset;
             // The caller must uphold that the given region is contained within that of `node`, and
             // it follows that if there is padding, the size of the node must be larger than that
             // of the padding, so this can't overflow.
-            unsafe { (*node_ptr.as_ptr()).size -= padding.size };
+            node.size -= padding.size;
 
-            if node_ptr == self.head {
-                self.head = padding_ptr;
+            if node_ptr == self.head_ptr {
+                self.head_ptr = padding_ptr;
             }
 
             self.len += 1;
 
             // SAFETY: We just created this suballocation, so there's no way that it was
             // deallocated already.
-            unsafe { self.deallocate(padding_ptr) };
+            unsafe { self.add_to_free_list(padding_ptr) };
         }
 
         if padding_back > 0 {
             let padding_ptr = self.node_allocator.allocate();
             let padding = SuballocationListNode {
-                prev: Some(node_ptr),
-                next: node.next,
+                prev_ptr: Some(node_ptr),
+                next_ptr: node.next_ptr,
                 offset: offset + size,
                 size: padding_back,
                 allocation_type: SuballocationType::Free,
             };
-            unsafe { padding_ptr.as_ptr().write(padding) };
+            unsafe { padding_ptr.write(padding) };
 
-            if let Some(next_ptr) = padding.next {
-                unsafe { (*next_ptr.as_ptr()).prev = Some(padding_ptr) };
+            if let Some(mut next_ptr) = padding.next_ptr {
+                let next = unsafe { next_ptr.as_mut() };
+                next.prev_ptr = Some(padding_ptr);
             }
 
-            unsafe { (*node_ptr.as_ptr()).next = Some(padding_ptr) };
+            node.next_ptr = Some(padding_ptr);
             // This is overflow-safe for the same reason as above.
-            unsafe { (*node_ptr.as_ptr()).size -= padding.size };
+            node.size -= padding.size;
 
-            if node_ptr == self.tail {
-                self.tail = padding_ptr;
+            if node_ptr == self.tail_ptr {
+                self.tail_ptr = padding_ptr;
             }
 
             self.len += 1;
 
             // SAFETY: Same as above.
-            unsafe { self.deallocate(padding_ptr) };
+            unsafe { self.add_to_free_list(padding_ptr) };
         }
     }
 
@@ -425,13 +398,14 @@ impl SuballocationList {
     /// # Safety
     ///
     /// - `node_ptr` must refer to a currently allocated suballocation of `self`.
-    unsafe fn deallocate(&mut self, node_ptr: NonNull<SuballocationListNode>) {
+    #[inline]
+    unsafe fn add_to_free_list(&mut self, node_ptr: NonNull<SuballocationListNode>) {
         debug_assert!(!self.free_list.contains(&node_ptr));
 
-        let node = unsafe { *node_ptr.as_ptr() };
+        let node = unsafe { node_ptr.as_ref() };
         let (Ok(index) | Err(index)) = self
             .free_list
-            .binary_search_by_key(&node, |&ptr| unsafe { *ptr.as_ptr() });
+            .binary_search_by_key(&node, |&ptr| unsafe { ptr.as_ref() });
         self.free_list.insert(index, node_ptr);
     }
 
@@ -440,30 +414,35 @@ impl SuballocationList {
     /// # Safety
     ///
     /// - `node_ptr` must refer to a currently free suballocation `self`.
-    unsafe fn coalesce(&mut self, node_ptr: NonNull<SuballocationListNode>) {
-        let node = unsafe { *node_ptr.as_ptr() };
+    /// - `node_ptr` must not be in the free-list yet.
+    #[inline]
+    unsafe fn coalesce(&mut self, mut node_ptr: NonNull<SuballocationListNode>) {
+        let node = unsafe { node_ptr.as_mut() };
 
         debug_assert_eq!(node.allocation_type, SuballocationType::Free);
+        debug_assert!(!self.free_list.contains(&node_ptr));
 
-        if let Some(prev_ptr) = node.prev {
-            let prev = unsafe { *prev_ptr.as_ptr() };
+        if let Some(prev_ptr) = node.prev_ptr {
+            let prev = unsafe { prev_ptr.as_ref() };
 
             if prev.allocation_type == SuballocationType::Free {
-                // SAFETY: We checked that the suballocation is free.
-                unsafe { self.allocate(prev_ptr) };
+                // SAFETY: We checked that the suballocation is free, which means that it must be
+                // in the free-list.
+                unsafe { self.remove_from_free_list(prev_ptr) };
 
-                unsafe { (*node_ptr.as_ptr()).prev = prev.prev };
-                unsafe { (*node_ptr.as_ptr()).offset = prev.offset };
+                node.prev_ptr = prev.prev_ptr;
+                node.offset = prev.offset;
                 // The sizes of suballocations are constrained by that of the parent allocation, so
                 // they can't possibly overflow when added up.
-                unsafe { (*node_ptr.as_ptr()).size += prev.size };
+                node.size += prev.size;
 
-                if let Some(prev_ptr) = prev.prev {
-                    unsafe { (*prev_ptr.as_ptr()).next = Some(node_ptr) };
+                if let Some(mut prev_ptr) = prev.prev_ptr {
+                    let prev = unsafe { prev_ptr.as_mut() };
+                    prev.next_ptr = Some(node_ptr);
                 }
 
-                if prev_ptr == self.head {
-                    self.head = node_ptr;
+                if prev_ptr == self.head_ptr {
+                    self.head_ptr = node_ptr;
                 }
 
                 self.len -= 1;
@@ -479,23 +458,24 @@ impl SuballocationList {
             }
         }
 
-        if let Some(next_ptr) = node.next {
-            let next = unsafe { *next_ptr.as_ptr() };
+        if let Some(next_ptr) = node.next_ptr {
+            let next = unsafe { next_ptr.as_ref() };
 
             if next.allocation_type == SuballocationType::Free {
                 // SAFETY: Same as above.
-                unsafe { self.allocate(next_ptr) };
+                unsafe { self.remove_from_free_list(next_ptr) };
 
-                unsafe { (*node_ptr.as_ptr()).next = next.next };
+                node.next_ptr = next.next_ptr;
                 // This is overflow-safe for the same reason as above.
-                unsafe { (*node_ptr.as_ptr()).size += next.size };
+                node.size += next.size;
 
-                if let Some(next_ptr) = next.next {
-                    unsafe { (*next_ptr.as_ptr()).prev = Some(node_ptr) };
+                if let Some(mut next_ptr) = next.next_ptr {
+                    let next = unsafe { next_ptr.as_mut() };
+                    next.prev_ptr = Some(node_ptr);
                 }
 
-                if next_ptr == self.tail {
-                    self.tail = node_ptr;
+                if next_ptr == self.tail_ptr {
+                    self.tail_ptr = node_ptr;
                 }
 
                 self.len -= 1;
@@ -511,36 +491,87 @@ impl SuballocationList {
     /// # Safety
     ///
     /// - `node_ptr` must refer to a currently free suballocation of `self`.
-    unsafe fn allocate(&mut self, node_ptr: NonNull<SuballocationListNode>) {
+    /// - `node_ptr` must be in the free-list.
+    #[inline]
+    unsafe fn remove_from_free_list(&mut self, node_ptr: NonNull<SuballocationListNode>) {
         debug_assert!(self.free_list.contains(&node_ptr));
 
-        let node = unsafe { *node_ptr.as_ptr() };
+        let node = unsafe { node_ptr.as_ref() };
 
-        match self
+        let Ok(index) = self
             .free_list
-            .binary_search_by_key(&node, |&ptr| unsafe { *ptr.as_ptr() })
-        {
-            Ok(index) => {
-                self.free_list.remove(index);
-            }
-            Err(_) => unreachable!(),
-        }
+            .binary_search_by_key(&node, |&ptr| unsafe { ptr.as_ref() })
+        else {
+            // SAFETY: The caller must ensure that `node_ptr` is in the free-list.
+            unsafe { hint::unreachable_unchecked() };
+        };
+
+        self.free_list.remove(index);
     }
 
+    fn reset(&mut self) {
+        self.free_list.clear();
+        unsafe { self.node_allocator.reset() };
+
+        let root_ptr = self.node_allocator.allocate();
+        let root = SuballocationListNode {
+            prev_ptr: None,
+            next_ptr: None,
+            offset: self.region.offset(),
+            size: self.region.size(),
+            allocation_type: SuballocationType::Free,
+        };
+        unsafe { root_ptr.write(root) };
+
+        self.head_ptr = root_ptr;
+        self.tail_ptr = root_ptr;
+        self.len = 1;
+        self.free_list.push(root_ptr);
+    }
+
+    #[inline]
     fn iter(&self) -> Suballocations<'_> {
         Suballocations {
-            head: Some(self.head),
-            tail: Some(self.tail),
+            head_ptr: Some(self.head_ptr),
+            tail_ptr: Some(self.tail_ptr),
             len: self.len,
             marker: PhantomData,
         }
     }
 }
 
+impl PartialEq for SuballocationListNode {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.size == other.size && self.offset == other.offset
+    }
+}
+
+impl Eq for SuballocationListNode {}
+
+impl PartialOrd for SuballocationListNode {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SuballocationListNode {
+    #[inline]
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        // We want to sort the free-list by size.
+        self.size
+            .cmp(&other.size)
+            // However there might be multiple free suballocations with the same size, so we need
+            // to compare the offset as well to differentiate.
+            .then(self.offset.cmp(&other.offset))
+    }
+}
+
 #[derive(Clone)]
 pub struct Suballocations<'a> {
-    head: Option<NonNull<SuballocationListNode>>,
-    tail: Option<NonNull<SuballocationListNode>>,
+    head_ptr: Option<NonNull<SuballocationListNode>>,
+    tail_ptr: Option<NonNull<SuballocationListNode>>,
     len: usize,
     marker: PhantomData<&'a SuballocationList>,
 }
@@ -554,9 +585,9 @@ impl Iterator for Suballocations<'_> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.len != 0 {
-            if let Some(head) = self.head {
-                let head = unsafe { *head.as_ptr() };
-                self.head = head.next;
+            if let Some(head_ptr) = self.head_ptr {
+                let head = unsafe { head_ptr.as_ref() };
+                self.head_ptr = head.next_ptr;
                 self.len -= 1;
 
                 Some(SuballocationNode {
@@ -587,9 +618,9 @@ impl DoubleEndedIterator for Suballocations<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.len != 0 {
-            if let Some(tail) = self.tail {
-                let tail = unsafe { *tail.as_ptr() };
-                self.tail = tail.prev;
+            if let Some(tail_ptr) = self.tail_ptr {
+                let tail = unsafe { tail_ptr.as_ref() };
+                self.tail_ptr = tail.prev_ptr;
                 self.len -= 1;
 
                 Some(SuballocationNode {

--- a/vulkano/src/memory/allocator/suballocator/free_list.rs
+++ b/vulkano/src/memory/allocator/suballocator/free_list.rs
@@ -74,28 +74,16 @@ unsafe impl Suballocator for FreeListAllocator {
     ///
     /// [region]: Suballocator#regions
     fn new(region: Region) -> Self {
-        let node_allocator = slabbin::SlabAllocator::<SuballocationListNode>::new(32);
-        let root_ptr = node_allocator.allocate();
-        let root = SuballocationListNode {
-            prev_ptr: None,
-            next_ptr: None,
-            offset: region.offset(),
-            size: region.size(),
-            allocation_type: SuballocationType::Free,
-        };
-        unsafe { root_ptr.write(root) };
-
-        let mut free_list = Vec::with_capacity(32);
-        free_list.push(root_ptr);
-
-        let suballocations = SuballocationList {
+        let mut suballocations = SuballocationList {
             region,
-            head_ptr: root_ptr,
-            tail_ptr: root_ptr,
-            len: 1,
-            free_list,
-            node_allocator,
+            head_ptr: NonNull::dangling(),
+            tail_ptr: NonNull::dangling(),
+            len: 0,
+            free_list: Vec::with_capacity(32),
+            node_allocator: slabbin::SlabAllocator::new(32),
         };
+
+        unsafe { suballocations.init() };
 
         FreeListAllocator {
             free_size: region.size(),
@@ -131,8 +119,8 @@ unsafe impl Suballocator for FreeListAllocator {
                 // suballocations with the same size, we get the first one of them, that is, the
                 // one with the lowest offset.
                 let dummy_node = SuballocationListNode {
-                    prev_ptr: None,
-                    next_ptr: None,
+                    prev_ptr: NonNull::dangling(),
+                    next_ptr: NonNull::dangling(),
                     offset: 0,
                     size,
                     allocation_type: SuballocationType::Unknown,
@@ -165,19 +153,17 @@ unsafe impl Suballocator for FreeListAllocator {
                     if buffer_image_granularity != DeviceAlignment::MIN {
                         debug_assert!(is_aligned(self.region().offset(), buffer_image_granularity));
 
-                        if let Some(prev_ptr) = node.prev_ptr {
-                            let prev = unsafe { prev_ptr.as_ref() };
+                        let prev = unsafe { node.prev_ptr.as_ref() };
 
-                            if are_blocks_on_same_page(
-                                prev.offset,
-                                prev.size,
-                                offset,
-                                buffer_image_granularity,
-                            ) && has_granularity_conflict(prev.allocation_type, allocation_type)
-                            {
-                                // This is overflow-safe for the same reason as above.
-                                offset = align_up(offset, buffer_image_granularity);
-                            }
+                        if are_blocks_on_same_page(
+                            prev.offset,
+                            prev.size,
+                            offset,
+                            buffer_image_granularity,
+                        ) && has_granularity_conflict(prev.allocation_type, allocation_type)
+                        {
+                            // This is overflow-safe for the same reason as above.
+                            offset = align_up(offset, buffer_image_granularity);
                         }
                     }
 
@@ -294,14 +280,52 @@ unsafe impl Sync for SuballocationList {}
 
 #[derive(Clone, Copy, Debug)]
 struct SuballocationListNode {
-    prev_ptr: Option<NonNull<Self>>,
-    next_ptr: Option<NonNull<Self>>,
+    prev_ptr: NonNull<Self>,
+    next_ptr: NonNull<Self>,
     offset: DeviceSize,
     size: DeviceSize,
     allocation_type: SuballocationType,
 }
 
 impl SuballocationList {
+    unsafe fn init(&mut self) {
+        let head_ptr = self.node_allocator.allocate();
+        let root_ptr = self.node_allocator.allocate();
+        let tail_ptr = self.node_allocator.allocate();
+
+        let head = SuballocationListNode {
+            prev_ptr: NonNull::dangling(),
+            next_ptr: root_ptr,
+            offset: self.region.offset(),
+            size: 0,
+            allocation_type: SuballocationType::Unknown,
+        };
+        unsafe { head_ptr.write(head) };
+
+        let root = SuballocationListNode {
+            prev_ptr: head_ptr,
+            next_ptr: tail_ptr,
+            offset: self.region.offset(),
+            size: self.region.size(),
+            allocation_type: SuballocationType::Free,
+        };
+        unsafe { root_ptr.write(root) };
+
+        let tail = SuballocationListNode {
+            prev_ptr: root_ptr,
+            next_ptr: NonNull::dangling(),
+            offset: self.region.offset() + self.region.size(),
+            size: 0,
+            allocation_type: SuballocationType::Unknown,
+        };
+        unsafe { tail_ptr.write(tail) };
+
+        self.head_ptr = head_ptr;
+        self.tail_ptr = tail_ptr;
+        self.len = 1;
+        self.free_list.push(root_ptr);
+    }
+
     /// Fits a suballocation inside the target one, splitting the target at the ends if required.
     ///
     /// # Safety
@@ -332,28 +356,22 @@ impl SuballocationList {
             let padding_ptr = self.node_allocator.allocate();
             let padding = SuballocationListNode {
                 prev_ptr: node.prev_ptr,
-                next_ptr: Some(node_ptr),
+                next_ptr: node_ptr,
                 offset: node.offset,
                 size: padding_front,
                 allocation_type: SuballocationType::Free,
             };
             unsafe { padding_ptr.write(padding) };
 
-            if let Some(mut prev_ptr) = padding.prev_ptr {
-                let prev = unsafe { prev_ptr.as_mut() };
-                prev.next_ptr = Some(padding_ptr);
-            }
+            let prev = unsafe { node.prev_ptr.as_mut() };
+            prev.next_ptr = padding_ptr;
 
-            node.prev_ptr = Some(padding_ptr);
+            node.prev_ptr = padding_ptr;
             node.offset = offset;
             // The caller must uphold that the given region is contained within that of `node`, and
             // it follows that if there is padding, the size of the node must be larger than that
             // of the padding, so this can't overflow.
             node.size -= padding.size;
-
-            if node_ptr == self.head_ptr {
-                self.head_ptr = padding_ptr;
-            }
 
             self.len += 1;
 
@@ -365,7 +383,7 @@ impl SuballocationList {
         if padding_back > 0 {
             let padding_ptr = self.node_allocator.allocate();
             let padding = SuballocationListNode {
-                prev_ptr: Some(node_ptr),
+                prev_ptr: node_ptr,
                 next_ptr: node.next_ptr,
                 offset: offset + size,
                 size: padding_back,
@@ -373,18 +391,12 @@ impl SuballocationList {
             };
             unsafe { padding_ptr.write(padding) };
 
-            if let Some(mut next_ptr) = padding.next_ptr {
-                let next = unsafe { next_ptr.as_mut() };
-                next.prev_ptr = Some(padding_ptr);
-            }
+            let next = unsafe { node.next_ptr.as_mut() };
+            next.prev_ptr = padding_ptr;
 
-            node.next_ptr = Some(padding_ptr);
+            node.next_ptr = padding_ptr;
             // This is overflow-safe for the same reason as above.
             node.size -= padding.size;
-
-            if node_ptr == self.tail_ptr {
-                self.tail_ptr = padding_ptr;
-            }
 
             self.len += 1;
 
@@ -422,67 +434,55 @@ impl SuballocationList {
         debug_assert_eq!(node.allocation_type, SuballocationType::Free);
         debug_assert!(!self.free_list.contains(&node_ptr));
 
-        if let Some(prev_ptr) = node.prev_ptr {
-            let prev = unsafe { prev_ptr.as_ref() };
+        let prev_ptr = node.prev_ptr;
+        let prev = unsafe { prev_ptr.as_ref() };
 
-            if prev.allocation_type == SuballocationType::Free {
-                // SAFETY: We checked that the suballocation is free, which means that it must be
-                // in the free-list.
-                unsafe { self.remove_from_free_list(prev_ptr) };
+        if prev.allocation_type == SuballocationType::Free {
+            // SAFETY: We checked that the suballocation is free, which means that it must be
+            // in the free-list.
+            unsafe { self.remove_from_free_list(prev_ptr) };
 
-                node.prev_ptr = prev.prev_ptr;
-                node.offset = prev.offset;
-                // The sizes of suballocations are constrained by that of the parent allocation, so
-                // they can't possibly overflow when added up.
-                node.size += prev.size;
+            node.prev_ptr = prev.prev_ptr;
+            node.offset = prev.offset;
+            // The sizes of suballocations are constrained by that of the parent allocation, so
+            // they can't possibly overflow when added up.
+            node.size += prev.size;
 
-                if let Some(mut prev_ptr) = prev.prev_ptr {
-                    let prev = unsafe { prev_ptr.as_mut() };
-                    prev.next_ptr = Some(node_ptr);
-                }
+            let mut prev_prev_ptr = prev.prev_ptr;
+            let prev_prev = unsafe { prev_prev_ptr.as_mut() };
+            prev_prev.next_ptr = node_ptr;
 
-                if prev_ptr == self.head_ptr {
-                    self.head_ptr = node_ptr;
-                }
+            self.len -= 1;
 
-                self.len -= 1;
-
-                // SAFETY:
-                // - The suballocation is free.
-                // - The suballocation was removed from the free-list.
-                // - The next suballocation and possibly a previous suballocation have been updated
-                //   such that they no longer reference the suballocation.
-                // - The head no longer points to the suballocation if it used to.
-                // All of these conditions combined guarantee that `prev_ptr` cannot be used again.
-                unsafe { self.node_allocator.deallocate(prev_ptr) };
-            }
+            // SAFETY:
+            // - The suballocation is free.
+            // - The suballocation was removed from the free-list.
+            // - The next suballocation and possibly a previous suballocation have been updated such
+            //   that they no longer reference the suballocation.
+            // - The head no longer points to the suballocation if it used to.
+            // All of these conditions combined guarantee that `prev_ptr` cannot be used again.
+            unsafe { self.node_allocator.deallocate(prev_ptr) };
         }
 
-        if let Some(next_ptr) = node.next_ptr {
-            let next = unsafe { next_ptr.as_ref() };
+        let next_ptr = node.next_ptr;
+        let next = unsafe { next_ptr.as_ref() };
 
-            if next.allocation_type == SuballocationType::Free {
-                // SAFETY: Same as above.
-                unsafe { self.remove_from_free_list(next_ptr) };
+        if next.allocation_type == SuballocationType::Free {
+            // SAFETY: Same as above.
+            unsafe { self.remove_from_free_list(next_ptr) };
 
-                node.next_ptr = next.next_ptr;
-                // This is overflow-safe for the same reason as above.
-                node.size += next.size;
+            node.next_ptr = next.next_ptr;
+            // This is overflow-safe for the same reason as above.
+            node.size += next.size;
 
-                if let Some(mut next_ptr) = next.next_ptr {
-                    let next = unsafe { next_ptr.as_mut() };
-                    next.prev_ptr = Some(node_ptr);
-                }
+            let mut next_next_ptr = next.next_ptr;
+            let next_next = unsafe { next_next_ptr.as_mut() };
+            next_next.prev_ptr = node_ptr;
 
-                if next_ptr == self.tail_ptr {
-                    self.tail_ptr = node_ptr;
-                }
+            self.len -= 1;
 
-                self.len -= 1;
-
-                // SAFETY: Same as above.
-                unsafe { self.node_allocator.deallocate(next_ptr) };
-            }
+            // SAFETY: Same as above.
+            unsafe { self.node_allocator.deallocate(next_ptr) };
         }
     }
 
@@ -512,28 +512,17 @@ impl SuballocationList {
     fn reset(&mut self) {
         self.free_list.clear();
         unsafe { self.node_allocator.reset() };
-
-        let root_ptr = self.node_allocator.allocate();
-        let root = SuballocationListNode {
-            prev_ptr: None,
-            next_ptr: None,
-            offset: self.region.offset(),
-            size: self.region.size(),
-            allocation_type: SuballocationType::Free,
-        };
-        unsafe { root_ptr.write(root) };
-
-        self.head_ptr = root_ptr;
-        self.tail_ptr = root_ptr;
-        self.len = 1;
-        self.free_list.push(root_ptr);
+        unsafe { self.init() };
     }
 
     #[inline]
     fn iter(&self) -> Suballocations<'_> {
+        let head_ptr = unsafe { self.head_ptr.as_ref() }.next_ptr;
+        let tail_ptr = unsafe { self.tail_ptr.as_ref() }.prev_ptr;
+
         Suballocations {
-            head_ptr: Some(self.head_ptr),
-            tail_ptr: Some(self.tail_ptr),
+            head_ptr,
+            tail_ptr,
             len: self.len,
             marker: PhantomData,
         }
@@ -570,8 +559,8 @@ impl Ord for SuballocationListNode {
 
 #[derive(Clone)]
 pub struct Suballocations<'a> {
-    head_ptr: Option<NonNull<SuballocationListNode>>,
-    tail_ptr: Option<NonNull<SuballocationListNode>>,
+    head_ptr: NonNull<SuballocationListNode>,
+    tail_ptr: NonNull<SuballocationListNode>,
     len: usize,
     marker: PhantomData<&'a SuballocationList>,
 }
@@ -585,19 +574,15 @@ impl Iterator for Suballocations<'_> {
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.len != 0 {
-            if let Some(head_ptr) = self.head_ptr {
-                let head = unsafe { head_ptr.as_ref() };
-                self.head_ptr = head.next_ptr;
-                self.len -= 1;
+            let head = unsafe { self.head_ptr.as_ref() };
+            self.head_ptr = head.next_ptr;
+            self.len -= 1;
 
-                Some(SuballocationNode {
-                    offset: head.offset,
-                    size: head.size,
-                    allocation_type: head.allocation_type,
-                })
-            } else {
-                None
-            }
+            Some(SuballocationNode {
+                offset: head.offset,
+                size: head.size,
+                allocation_type: head.allocation_type,
+            })
         } else {
             None
         }
@@ -618,19 +603,15 @@ impl DoubleEndedIterator for Suballocations<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.len != 0 {
-            if let Some(tail_ptr) = self.tail_ptr {
-                let tail = unsafe { tail_ptr.as_ref() };
-                self.tail_ptr = tail.prev_ptr;
-                self.len -= 1;
+            let tail = unsafe { self.tail_ptr.as_ref() };
+            self.tail_ptr = tail.prev_ptr;
+            self.len -= 1;
 
-                Some(SuballocationNode {
-                    offset: tail.offset,
-                    size: tail.size,
-                    allocation_type: tail.allocation_type,
-                })
-            } else {
-                None
-            }
+            Some(SuballocationNode {
+                offset: tail.offset,
+                size: tail.size,
+                allocation_type: tail.allocation_type,
+            })
         } else {
             None
         }

--- a/vulkano/src/memory/allocator/suballocator/mod.rs
+++ b/vulkano/src/memory/allocator/suballocator/mod.rs
@@ -8,7 +8,7 @@ pub use self::{
     buddy::BuddyAllocator, bump::BumpAllocator, free_list::FreeListAllocator, region::Region,
 };
 use super::{align_down, AllocationHandle, DeviceAlignment, DeviceLayout};
-use crate::{image::ImageTiling, DeviceSize};
+use crate::{image::ImageTiling, memory::allocator::align_up, DeviceSize};
 use std::{
     error::Error,
     fmt::{self, Debug, Display},
@@ -648,23 +648,24 @@ impl From<AllocationType> for SuballocationType {
 ///
 /// > Note
 /// >
-/// > Assumes `a_offset + a_size > 0` and `a_offset + a_size <= b_offset`.
+/// > Assumes `a_offset + a_size <= b_offset` and that `align_up(a_offset + a_size, page_size)`
+/// > doesn't overflow.
 ///
 /// </div>
+#[inline]
 fn are_blocks_on_same_page(
     a_offset: DeviceSize,
     a_size: DeviceSize,
     b_offset: DeviceSize,
     page_size: DeviceAlignment,
 ) -> bool {
-    debug_assert!(a_offset + a_size > 0);
-    debug_assert!(a_offset + a_size <= b_offset);
-
-    let a_end = a_offset + a_size - 1;
-    let a_end_page = align_down(a_end, page_size);
+    let a_end_page_plus_one = align_up(a_offset + a_size, page_size);
     let b_start_page = align_down(b_offset, page_size);
 
-    a_end_page == b_start_page
+    debug_assert!(a_offset + a_size <= b_offset);
+    debug_assert!(!(a_offset + a_size > 0 && a_end_page_plus_one == 0));
+
+    a_end_page_plus_one > b_start_page
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In the first commit, I refactored `FreeListAllocator`, which includes:
- Bringing it up to speed with our MSRV, i.e. instead of having to spam `.as_ptr()`, `NonNull` now has the same methods as the underlying pointer, which makes the code simpler.
- Removing the needless copying of the `SuballocationListNode` struct, using references instead.
- Making it consistent with the new implementation of `BuddyAllocator`.

In the second commit, I added sentinel nodes to `FreeListAllocator`'s and `BuddyAllocator`'s suballocation lists. This removes the checks for whether the node has a previous/next node, as well as the checks for whether the node is the head/tail/both. Additionally, it removes a branch in the iterators, and makes `BuddyAllocator::iter` O(1).

I suggest reviewing one commit at a time.