### PR TITLE
use crate_ident in derive_buffer_contents hack

### DIFF
--- a/vulkano-macros/src/derive_buffer_contents.rs
+++ b/vulkano-macros/src/derive_buffer_contents.rs
@@ -168,7 +168,7 @@ pub fn derive_buffer_contents(crate_ident: &Ident, mut ast: DeriveInput) -> Resu
             // HACK: This works around Rust issue #48214, which makes it impossible to put these
             // bounds in the where clause of the trait implementation where they actually belong
             // until that is resolved.
-            let _: ::vulkano::buffer::AssertParamIsBufferContents<#ty>;
+            let _: ::#crate_ident::buffer::AssertParamIsBufferContents<#ty>;
         }
     });
 


### PR DESCRIPTION
fix a very small mistake in the `derive_buffer_contents` macro that made it incompatible with using `vulkano` under another name.